### PR TITLE
docs(samples): Add Spectre sample app and getting-started guide

### DIFF
--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -150,6 +150,19 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: dotnet sonarscanner end /d:sonar.login="$SONAR_TOKEN"
 
+      # The sample application is a standalone solution outside SOLUTION_PATH: by design it consumes
+      # the libraries as NuGet packages, so the main build never compiles it. Build it against the
+      # library sources on every run - otherwise a change to a command base class breaks the sample
+      # silently and nobody finds out until someone opens it. -p:UsePlochProjectReferences=true
+      # swaps its PackageReferences for ProjectReferences (see samples/SampleApp/README.md).
+      #
+      # Placed after "SonarScanner End" on purpose: the scanner captures every MSBuild project built
+      # between begin and end, and the sample is deliberately excluded from analysis (it also
+      # already sits in sonar.coverage.exclusions). Not continue-on-error - a broken sample is a
+      # broken build.
+      - name: Build sample application
+        run: dotnet build ./samples/SampleApp/Ploch.CommandLine.Spectre.SampleApp.slnx -c Release -p:UsePlochProjectReferences=true
+
       - name: Run codacy-coverage-reporter
         if: always()
         continue-on-error: true

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,0 +1,721 @@
+# Getting Started with Ploch.CommandLine.Spectre
+
+A hands-on walkthrough: you build a small CLI from an empty directory, one feature at a time, and
+run it after every step. Every console listing below is real output captured from the finished
+application, not an illustration.
+
+For the conceptual overview — what each package is for, how the pieces fit together — see the
+documentation site home page and the *Introduction* article. This guide is deliberately practical
+and does not repeat them.
+
+The finished application lives in [`samples/SampleApp`](../samples/SampleApp/README.md). If you
+would rather read the code than type it, start there.
+
+## Contents
+
+1. [Prerequisites](#1-prerequisites)
+2. [Create the project](#2-create-the-project)
+3. [Bootstrap the application with AppBuilder](#3-bootstrap-the-application-with-appbuilder)
+4. [Your first command: settings and AppCommand](#4-your-first-command-settings-and-appcommand)
+5. [Configuration that survives the working directory](#5-configuration-that-survives-the-working-directory)
+6. [Asynchronous commands and dependency injection](#6-asynchronous-commands-and-dependency-injection)
+7. [Composing a multi-level CLI](#7-composing-a-multi-level-cli)
+8. [Validating settings with FluentValidation](#8-validating-settings-with-fluentvalidation)
+9. [Token expansion in settings](#9-token-expansion-in-settings)
+10. [Use cases and Ardalis.Result](#10-use-cases-and-ardalisresult)
+11. [Exit codes](#11-exit-codes)
+12. [Cancellation](#12-cancellation)
+13. [Logging with Serilog](#13-logging-with-serilog)
+14. [Testing commands](#14-testing-commands)
+15. [Development conveniences](#15-development-conveniences)
+
+---
+
+## 1. Prerequisites
+
+- .NET SDK 10.0 or later (`dotnet --version`).
+- A NuGet feed carrying the `Ploch.*` packages. They are published to the MrPloch GitHub Packages
+  feed; see the repository README for the feed URL and authentication.
+
+## 2. Create the project
+
+```bash
+dotnet new console -n MyTool
+cd MyTool
+dotnet add package Ploch.CommandLine.Spectre
+dotnet add package Spectre.Console.Cli
+```
+
+Add the optional packages as you reach the steps that need them:
+
+| Package | Adds |
+|---|---|
+| `Ploch.CommandLine.Spectre` | `AppBuilder`, the command base classes, `IOutput`, exit codes, token processing |
+| `Ploch.CommandLine.Spectre.FluentValidation` | FluentValidation-backed settings validation |
+| `Ploch.CommandLine.Spectre.Serilog` | Serilog wiring with console and rolling-file sinks |
+| `Ploch.CommandLine.UseCases` | `IResultUseCase<,>` and `UseCaseAsyncCommand<,,,>` |
+
+## 3. Bootstrap the application with AppBuilder
+
+`AppBuilder` builds a `Microsoft.Extensions.Hosting` host, wires its service provider into
+`Spectre.Console.Cli`, and returns an executor you run with the process arguments.
+
+```csharp
+using Ploch.CommandLine.Spectre;
+
+var executor = AppBuilder.Create(args)
+                         .WithName("My Tool")
+                         .WithVersion(new Version(1, 0, 0))
+                         .WithDescription("Does something useful.")
+                         .ConfigureCommandApp(config =>
+                         {
+                             config.SetApplicationName("mytool");
+                         });
+
+return executor.Run(args);
+```
+
+Three things happen here that you do not have to write yourself:
+
+- **Application banner.** The name is rendered as FIGlet text, followed by the version and
+  description, before any command runs.
+- **Hosting.** `Host.CreateDefaultBuilder` supplies configuration, logging and the service
+  provider. Anything you register with `ConfigureServices` is injectable into commands.
+- **Ctrl+C.** `AppBuilder.Create` installs a `Console.CancelKeyPress` handler that cancels a
+  `CancellationTokenSource` instead of killing the process, which is what the token your commands
+  receive is linked to (see [Cancellation](#12-cancellation)).
+
+`ConfigureServices` has two overloads — one taking just `IServiceCollection`, one taking the
+`HostBuilderContext` as well, which is how you reach `IConfiguration` during registration:
+
+```csharp
+.ConfigureServices((context, services) =>
+{
+    services.AddSingleton<IUserService, UserService>();
+    services.Configure<MyOptions>(context.Configuration.GetSection("MyOptions"));
+})
+```
+
+## 4. Your first command: settings and AppCommand
+
+A command is a pair: a **settings** class describing the command line, and a **command** class
+doing the work.
+
+Settings derive from Spectre's `CommandSettings` and use its attributes. `[CommandArgument]` is
+positional (`<REQUIRED>` in angle brackets, `[OPTIONAL]` in square ones); `[CommandOption]` is a
+named flag; `[Description]` feeds the generated help; `[DefaultValue]` supplies the default and is
+also shown in help.
+
+```csharp
+using System.ComponentModel;
+using Spectre.Console.Cli;
+
+public class InfoCommandSettings : CommandSettings
+{
+    [CommandOption("-d|--diagnostics")]
+    [Description("Display extended runtime and host diagnostics.")]
+    [DefaultValue(false)]
+    public bool ShowDiagnostics { get; set; }
+}
+```
+
+For synchronous work, derive from `AppCommand<TSettings>` and implement `DoExecute`:
+
+```csharp
+using Ploch.CommandLine.Spectre.Commands;
+using Ploch.CommandLine.Spectre.Output;
+using Spectre.Console.Cli;
+
+public class InfoCommand(ICommandSettingsValidator<InfoCommandSettings> validator,
+                         IExceptionHandler exceptionHandler,
+                         IOutput output) : AppCommand<InfoCommandSettings>(validator, exceptionHandler)
+{
+    protected override ExitCode DoExecute(CommandContext? context, InfoCommandSettings settings, CancellationToken cancellationToken)
+    {
+        output.MarkupLineInterpolated($"[bold cyan]Hello from My Tool[/]");
+
+        return ExitCode.Success;
+    }
+}
+```
+
+Note what the base class gives you and what you therefore never write in `DoExecute`:
+
+- **Validation** runs first, through the injected `ICommandSettingsValidator<TSettings>`.
+- **Exceptions** never escape. Anything thrown goes to the injected `IExceptionHandler`, whose
+  return value becomes the exit code.
+- **Cancellation** is separated from failure: an `OperationCanceledException` is not treated as a
+  fault, it returns `ExitCode.Cancelled`.
+- **`ExitCode`, not `int`.** The base class casts for you.
+
+`AppCommand<TSettings>` has no `Output` property — use the `IOutput` you injected. Its asynchronous
+sibling, introduced in step 6, does expose `Output`.
+
+Register the command and run it:
+
+```csharp
+config.AddCommand<InfoCommand>("info")
+      .WithDescription("Display system, application, and host runtime information.")
+      .WithExample("info")
+      .WithExample("info", "-d");
+```
+
+```text
+$ mytool info
+
+=== Application & System Information ===
+
+╭──────────────────────┬────────────────────────────────────────────╮
+│ Property             │ Value                                      │
+├──────────────────────┼────────────────────────────────────────────┤
+│ Application Name     │ Ploch.CommandLine.Spectre Sample App       │
+│ Framework            │ .NET 10.0.11                               │
+│ OS Description       │ Microsoft Windows 10.0.26200               │
+│ Process Architecture │ X64                                        │
+│ Current Directory    │ C:\DevNet\my\mrploch\ploch-commandline-wt9 │
+│ Machine Name         │ KPLOCH-MSI                                 │
+│ Environment Setting  │ Development                                │
+╰──────────────────────┴────────────────────────────────────────────╯
+
+Command completed successfully.
+```
+
+The `WithExample` calls are not decoration — they are what fills the `EXAMPLES:` block of the
+generated help.
+
+## 5. Configuration that survives the working directory
+
+Add an `appsettings.json` and copy it to the output directory:
+
+```xml
+<ItemGroup>
+  <None Update="appsettings.json">
+    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+  </None>
+</ItemGroup>
+```
+
+There is a trap here that only shows up once you install the tool. The host resolves relative
+configuration paths against the **current working directory**, and a CLI is run from wherever the
+user happens to be — so `appsettings.json` silently fails to load and every setting reads back as
+`null`. Anchor it to the deployment directory instead:
+
+```csharp
+.ConfigureAppConfiguration(configuration => configuration.SetBasePath(AppContext.BaseDirectory)
+                                                         .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true))
+```
+
+`optional: false` is deliberate: a missing configuration file should fail loudly at start-up rather
+than produce a tool that behaves differently depending on the directory it was launched from.
+
+Inject `IConfiguration` into a command like any other service.
+
+**Do not enumerate the configuration root for display.** The host adds an environment-variable
+provider, so `configuration.GetChildren()` yields every environment variable of the process — API
+keys and access tokens included. If a command renders configuration, give it an allow-list of the
+sections your application owns:
+
+```csharp
+private static readonly string[] ApplicationSections = ["SampleAppSettings", "Logging", "Serilog"];
+```
+
+## 6. Asynchronous commands and dependency injection
+
+`AsyncAppCommand<TSettings>` is the asynchronous base class. It takes two more dependencies than
+`AppCommand<TSettings>` — a `CommandArgumentsRootProcessor` (which pre-processes settings, e.g.
+token expansion) and an `IOutput`, exposed to you as the `Output` property.
+
+```csharp
+public class UserAddCommand(CommandArgumentsRootProcessor settingsProcessor,
+                            ICommandSettingsValidator<UserAddCommandSettings> validator,
+                            IExceptionHandler exceptionHandler,
+                            IOutput output,
+                            IUserService userService)
+    : AsyncAppCommand<UserAddCommandSettings>(settingsProcessor, validator, exceptionHandler, output)
+{
+    protected override async Task<ExitCode> DoExecuteAsync(CommandContext context,
+                                                           UserAddCommandSettings settings,
+                                                           CancellationToken cancellationToken)
+    {
+        Output.MarkupLineInterpolated($"[cyan]Creating new user account for[/] [bold yellow]{settings.Name}[/]...");
+
+        var user = await userService.CreateUserAsync(settings.Name, settings.Email, settings.Role, cancellationToken);
+
+        return ExitCode.Success;
+    }
+}
+```
+
+Use the inherited `Output` property rather than capturing the constructor parameter — capturing a
+parameter that is also passed to the base constructor stores it twice and the compiler warns about
+it (CS9107).
+
+`IUserService` is resolved from the container you configured in step 3; command constructors are
+plain constructor injection.
+
+```text
+$ mytool user add "Alice Smith" -e alice@example.com -r Administrator
+
+Executing command UserAddCommandSettings
+
+Processing arguments...
+Creating new user account for Alice Smith...
+╭─User Created Successfully────────╮
+│ User ID: 4                       │
+│ Name: Alice Smith                │
+│ Email: alice@example.com         │
+│ Role: Administrator              │
+│ Active: Yes                      │
+│ Created: 2026-08-22 12:37:59 UTC │
+╰──────────────────────────────────╯
+```
+
+The `Executing command …` / `Processing arguments…` preamble comes from `AsyncAppCommand`, not from
+the command body.
+
+## 7. Composing a multi-level CLI
+
+Sub-commands are grouped into **branches**. A branch is a verb with no behaviour of its own that
+owns a set of commands, and branches can be nested to any depth.
+
+```csharp
+var executor = appBuilder.ConfigureCommandApp(config =>
+{
+    config.SetApplicationName("sample");
+
+    // Root-level command.
+    config.AddCommand<InfoCommand>("info")
+          .WithDescription("Display system, application, and host runtime information.");
+
+    // A branch with three sub-commands.
+    config.AddBranch("user", user =>
+    {
+        user.SetDescription("Manage user accounts and profile data.");
+
+        user.AddCommand<UserAddCommand>("add")
+            .WithDescription("Create a new user account with validation.")
+            .WithExample("user", "add", "Alice Smith", "-e", "alice@example.com", "-r", "Administrator");
+
+        user.AddCommand<UserListCommand>("list")
+            .WithDescription("List registered user accounts in a rich table.");
+
+        user.AddCommand<UserDeleteCommand>("delete")
+            .WithDescription("Delete a user account by ID.");
+    });
+});
+```
+
+Help is generated for every level. The root:
+
+```text
+$ sample --help
+
+USAGE:
+    sample [OPTIONS] <COMMAND>
+
+EXAMPLES:
+    sample info
+    sample info -d
+    sample user add Alice Smith -e alice@example.com -r Administrator
+    sample user list
+    sample user list -a -f compact
+
+OPTIONS:
+    -h, --help    Prints help information
+
+COMMANDS:
+    info       Display system, application, and host runtime information
+    user       Manage user accounts and profile data
+    config     Inspect and manage application configuration settings
+    file       File processing and report generation utilities
+    project    Project operations powered by Clean Architecture use cases and
+               Ardalis.Result
+```
+
+And the branch:
+
+```text
+$ sample user --help
+
+DESCRIPTION:
+Manage user accounts and profile data
+
+USAGE:
+    sample user [OPTIONS] <COMMAND>
+
+EXAMPLES:
+    sample user add Alice Smith -e alice@example.com -r Administrator
+    sample user list
+    sample user list -a -f compact
+    sample user delete 1 --force
+
+OPTIONS:
+    -h, --help    Prints help information
+
+COMMANDS:
+    add <NAME>     Create a new user account with validation
+    list           List registered user accounts in a rich table
+    delete <ID>    Delete a user account by ID
+```
+
+Nesting further is the same call again — `user.AddBranch("keys", keys => …)` gives you
+`sample user keys rotate`.
+
+### Options shared by a group of commands
+
+Declare an option once in a base settings class and inherit it, rather than repeating the property
+on every command in a branch:
+
+```csharp
+public class GlobalSettings : CommandSettings
+{
+    [CommandOption("-v|--verbose")]
+    [Description("Enable verbose console output.")]
+    [DefaultValue(false)]
+    public bool Verbose { get; set; }
+}
+
+public class UserListCommandSettings : GlobalSettings
+{
+    [CommandOption("-a|--active-only")]
+    [Description("Only display active user accounts.")]
+    [DefaultValue(false)]
+    public bool ActiveOnly { get; set; }
+}
+```
+
+Inherited options appear in the generated help of every derived command, defaults included:
+
+```text
+$ sample user list --help
+
+OPTIONS:
+                             DEFAULT
+    -h, --help                          Prints help information
+    -v, --verbose                       Enable verbose console output
+    -a, --active-only                   Only display active user accounts
+    -f, --format <FORMAT>    table      The output format: 'table' or 'compact'
+```
+
+An option that appears in help must do something in every command that inherits it — a flag the
+command silently ignores is worse than no flag.
+
+## 8. Validating settings with FluentValidation
+
+Add the package, then register validation once during service configuration. Assembly scanning
+picks up every `AbstractValidator<TSettings>` in the assemblies you list:
+
+```csharp
+using Ploch.CommandLine.Spectre.FluentValidation;
+
+services.AddCommandLineSettingsFluentValidation(builder => builder.AddAssembly(typeof(Program).Assembly));
+```
+
+This registers `FluentCommandSettingsValidator<T>` as the `ICommandSettingsValidator<T>` your
+commands receive, so no command code changes.
+
+```csharp
+public class UserAddCommandSettingsValidator : AbstractValidator<UserAddCommandSettings>
+{
+    public UserAddCommandSettingsValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty().WithMessage("User name is required.")
+            .MinimumLength(2).WithMessage("User name must be at least 2 characters long.");
+
+        RuleFor(x => x.Email)
+            .NotEmpty().WithMessage("User email is required.")
+            .EmailAddress().WithMessage("A valid email address must be provided.");
+    }
+}
+```
+
+Validation runs before `DoExecuteAsync`, so an invalid invocation never reaches your code:
+
+```text
+$ sample user add "A" -e "invalid-email"
+
+Error: User name must be at least 2 characters long.
+A valid email address must be provided.
+```
+
+**Mind the exit code.** A failed `Validate` is reported by `Spectre.Console.Cli` itself, which
+short-circuits with its own exit code of `-1` (`255` as the shell sees it) — *not* with
+`ExitCode.InvalidInput`. `ExitCode.InvalidInput` is what your command returns when it rejects input
+itself; see [Exit codes](#11-exit-codes).
+
+## 9. Token expansion in settings
+
+Mark a string setting with `[SupportsTokens]` and the `CommandArgumentsRootProcessor` rewrites its
+value before `DoExecuteAsync` runs. `{date}` and `{datetime}` are resolved out of the box.
+
+```csharp
+[CommandOption("-o|--output-path <PATH>")]
+[Description("Output destination path. Supports tokens like '{date}' and '{datetime}'.")]
+[SupportsTokens]
+[DefaultValue("./processed-{date}/output.dat")]
+public string OutputPath { get; set; } = "./processed-{date}/output.dat";
+```
+
+The command body sees the expanded value, never the template:
+
+```text
+$ sample file process dataset.csv -o "./out-{date}/result.dat"
+
+Executing command FileProcessCommandSettings
+
+Processing arguments...
+Processing File: dataset.csv
+Resolved Output Path (with tokens replaced): ./out-2026-08-22/result.dat
+Backup enabled: True
+
+Processing file content...
+File processed successfully!
+Saved result to: ./out-2026-08-22/result.dat
+```
+
+Token expansion only happens for commands whose base class runs the settings processor — the
+asynchronous ones. `AppCommand<TSettings>` does not take a processor.
+
+## 10. Use cases and Ardalis.Result
+
+When the real work belongs in an application layer rather than in the CLI, put it in an
+`IResultUseCase<TRequest, TResponse>` and let `UseCaseAsyncCommand<,,,>` do the plumbing.
+
+```csharp
+public class CreateProjectUseCase(IProjectRepository projectRepository)
+    : IResultUseCase<CreateProjectRequest, CreateProjectResponse>
+{
+    public async Task<Result<CreateProjectResponse>> ExecuteAsync(CreateProjectRequest request,
+                                                                  CancellationToken cancellationToken = default)
+    {
+        var existing = await projectRepository.GetByNameAsync(request.Name, cancellationToken);
+        if (existing != null)
+        {
+            return Result<CreateProjectResponse>.Conflict($"A project with name '{request.Name}' already exists.");
+        }
+
+        var project = new ProjectItem(request.Name, request.Description, request.Template, DateTime.UtcNow);
+        await projectRepository.AddAsync(project, cancellationToken);
+
+        return Result<CreateProjectResponse>.Success(new(project.Name, project.Description, project.Template, project.CreatedAt));
+    }
+}
+```
+
+The command shrinks to a single mapping method — everything else, including rendering the result,
+is inherited:
+
+```csharp
+public class ProjectCreateCommand(IOutput output,
+                                  CreateProjectUseCase useCase,
+                                  CommandArgumentsRootProcessor settingsProcessor,
+                                  ICommandSettingsValidator<ProjectCreateCommandSettings> validator,
+                                  IExceptionHandler exceptionHandler)
+    : UseCaseAsyncCommand<ProjectCreateCommandSettings, CreateProjectUseCase, CreateProjectRequest, CreateProjectResponse>(
+        output, useCase, settingsProcessor, validator, exceptionHandler)
+{
+    protected override CreateProjectRequest CreateRequest(ProjectCreateCommandSettings commandSettings) =>
+        new(commandSettings.Name, commandSettings.Description, commandSettings.Template);
+}
+```
+
+Success and failure are rendered by the base class, which returns `ExitCode.Success` and
+`ExitCode.Error` respectively. Override `ProcessSuccessResponse` or `ProcessFailureResponse` to
+change either.
+
+```text
+$ sample project create MicroserviceDemo -d "Cloud native backend" -t WebAPI
+
+Starting use case CreateProjectUseCase
+Settings:
+Name: MicroserviceDemo
+Description: Cloud native backend
+Template: WebAPI
+Use case completed successfully.
+```
+
+```text
+$ sample project create SpectreDemo
+
+Starting use case CreateProjectUseCase
+Settings:
+Name: SpectreDemo
+Description: Sample project
+Template: Console
+Use case failed: A project with name 'SpectreDemo' already exists.
+
+[exit code 1]
+```
+
+## 11. Exit codes
+
+`ExitCode` is the contract between your commands and whatever script calls them.
+
+| Member | Value | Meaning |
+|---|---|---|
+| `Success` | 0 | The command completed. |
+| `Error` | 1 | The command ran and failed. |
+| `InvalidInput` | 2 | The command rejected the input it was given. |
+| `Cancelled` | 130 | The command stopped because cancellation was requested (128 + SIGINT). |
+
+Two exit codes do **not** come from this enumeration:
+
+- **`-1`** — `Spectre.Console.Cli` could not bind or validate the command line (unknown command,
+  missing required argument, failed `Validate`). It is produced before your command runs.
+- **Whatever `IExceptionHandler` returns** — an unhandled exception inside a command is routed to
+  the handler, and the handler's return value is the exit code.
+
+Return `InvalidInput` from a command when the input parses fine but is not acceptable — a value
+outside a supported set, a file that does not exist, mutually exclusive flags:
+
+```csharp
+if (!SupportedFormats.Contains(settings.Format, StringComparer.OrdinalIgnoreCase))
+{
+    Output.MarkupLineInterpolated($"[red]Unsupported format '{settings.Format}'. Supported formats: {string.Join(", ", SupportedFormats)}.[/]");
+
+    return ExitCode.InvalidInput;
+}
+```
+
+```text
+$ sample user list -f xml
+Unsupported format 'xml'. Supported formats: table, compact.
+
+$ echo $LASTEXITCODE
+2
+```
+
+## 12. Cancellation
+
+Every `DoExecute` / `DoExecuteAsync` receives a `CancellationToken`. Forward it — into service
+calls, `Task.Delay`, HTTP requests, database queries. A command that accepts the token and ignores
+it cannot be interrupted.
+
+```csharp
+protected override async Task<ExitCode> DoExecuteAsync(CommandContext context,
+                                                       FileProcessCommandSettings settings,
+                                                       CancellationToken cancellationToken)
+{
+    await AnsiConsole.Status()
+                     .Spinner(Spinner.Known.Dots)
+                     .StartAsync("Processing file content...",
+                                 async _ => await Task.Delay(TimeSpan.FromMilliseconds(300), cancellationToken));
+
+    return ExitCode.Success;
+}
+```
+
+The base class treats cancellation as an outcome rather than a fault: an `OperationCanceledException`
+is not passed to `IExceptionHandler`, it becomes `ExitCode.Cancelled` (130).
+
+## 13. Logging with Serilog
+
+`Ploch.CommandLine.Spectre.Serilog` configures Serilog as the logging provider, with a console sink
+and two rolling files — everything, and errors and warnings only:
+
+```csharp
+using Ploch.CommandLine.Spectre.Serilog;
+
+.ConfigureServices((context, services) =>
+{
+    services.AddSerilog(context.Configuration,
+                        logName: "sample",
+                        logPath: Path.Combine(AppContext.BaseDirectory, "logs"));
+})
+```
+
+Levels come from the `Serilog` section of `appsettings.json`:
+
+```json
+{
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": { "Microsoft": "Warning", "System": "Warning" }
+    }
+  }
+}
+```
+
+Inject `ILogger<TCommand>` into a command and use it for the operator's record, keeping `IOutput`
+for what the user reads:
+
+```csharp
+logger.LogWarning("[UserDeleteCommand] Delete requested for unknown user {UserId}", settings.Id);
+Output.MarkupLineInterpolated($"[red]User with ID {settings.Id} was not found.[/]");
+```
+
+```text
+$ cat logs/sample.log
+2026-08-22 14:36:16.690 +02:00 [WRN] [UserDeleteCommand] Delete requested for unknown user 99
+
+$ cat logs/sample-errors.log
+[14:36:16 WRN] [Ploch.CommandLine.Spectre.SampleApp.Commands.Users.UserDeleteCommand] [UserDeleteCommand] Delete requested for unknown user 99
+```
+
+## 14. Testing commands
+
+Commands are ordinary classes with constructor dependencies, so they are tested without a host.
+Construct the command with test doubles, build a `CommandContext`, and call the public
+`Execute` / `ExecuteAsync` — that path exercises validation, exception handling and cancellation as
+well as your `DoExecute` body.
+
+```csharp
+public class UserListCommandTests
+{
+    private readonly Mock<ICommandSettingsValidator<UserListCommandSettings>> _validatorMock = new();
+    private readonly Mock<IExceptionHandler> _exceptionHandlerMock = new();
+    private readonly Mock<IOutput> _outputMock = new();
+    private readonly Mock<IUserService> _userServiceMock = new();
+    private readonly CommandArgumentsRootProcessor _processor = new([]);
+
+    [Fact]
+    public async Task ExecuteAsync_should_return_invalid_input_when_the_format_is_not_supported()
+    {
+        var settings = new UserListCommandSettings { Format = "xml" };
+        var context = new CommandContext([], Mock.Of<IRemainingArguments>(), "list", null);
+
+        var command = new UserListCommand(_processor,
+                                          _validatorMock.Object,
+                                          _exceptionHandlerMock.Object,
+                                          _outputMock.Object,
+                                          _userServiceMock.Object);
+
+        var result = await command.ExecuteAsync(context, settings, CancellationToken.None);
+
+        result.Should().Be((int)ExitCode.InvalidInput);
+    }
+}
+```
+
+Two things worth testing that are easy to overlook:
+
+- **Token expansion.** Give the processor a `TokensArgumentsProcessor`
+  (`new CommandArgumentsRootProcessor([new TokensArgumentsProcessor()])`) and assert the setting was
+  rewritten.
+- **Cancellation.** Pass an already-cancelled token and assert `ExitCode.Cancelled`, plus that the
+  exception handler was never called — that proves cancellation is not being reported as a failure.
+
+## 15. Development conveniences
+
+Set `DEV_RUNTIME_CONSOLE_EXIT_PAUSE=true` and the application waits for Enter before exiting, so a
+console window launched from an IDE does not close before you can read it. It is read from the
+environment, so it never affects a build server or an end user who has not set it.
+
+Environment variables prefixed `DEV_RUNTIME` are collected into `EnvironmentSettings.Current`
+alongside the debugger state.
+
+---
+
+## Running the sample
+
+```bash
+# From the repository root, against the library sources in this repository:
+dotnet run --project samples/SampleApp/src/SampleApp -p:UsePlochProjectReferences=true -- --help
+dotnet test samples/SampleApp/Ploch.CommandLine.Spectre.SampleApp.slnx -p:UsePlochProjectReferences=true
+```
+
+See [`samples/SampleApp/README.md`](../samples/SampleApp/README.md) for the full command tour and
+for the difference between the standalone (NuGet) and in-repository (project reference) build
+modes.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -273,6 +273,29 @@ Creating new user account for Alice Smith...
 The `Executing command …` / `Processing arguments…` preamble comes from `AsyncAppCommand`, not from
 the command body.
 
+### Render through IOutput, and escape what the user typed
+
+Two habits worth forming early, both visible throughout the sample.
+
+**Render renderables through `IOutput`, not the static `AnsiConsole`.** `IOutput.Write(IRenderable)`
+takes a `Table`, `Panel` or `Tree` just as `AnsiConsole.Write` does, but it goes through the console
+the host configured and can be mocked in a test:
+
+```csharp
+Output.Write(table);        // not AnsiConsole.Write(table)
+```
+
+**Escape values that came from outside your source file.** Table cells, panel content, tree nodes
+and `Markup` are all parsed as Spectre markup, so a user name, path or configuration value
+containing `[` throws during rendering or injects formatting:
+
+```csharp
+table.AddRow(user.Id.ToString(), Markup.Escape(user.Name), Markup.Escape(user.Email));
+```
+
+`MarkupLineInterpolated` escapes its interpolation holes automatically — that is the difference
+between it and building a `Markup` from an interpolated string, which does not.
+
 ## 7. Composing a multi-level CLI
 
 Sub-commands are grouped into **branches**. A branch is a verb with no behaviour of its own that
@@ -586,6 +609,20 @@ $ echo $LASTEXITCODE
 2
 ```
 
+A destructive command needs the same discipline in reverse: confirm before acting, and distinguish
+"you did not tell me it was safe to proceed" from "you told me to stop".
+
+```csharp
+if (!AnsiConsole.Profile.Capabilities.Interactive)
+{
+    Output.MarkupLineInterpolated($"[yellow]Refusing to delete user {userId} without confirmation. Re-run with --force.[/]");
+
+    return ExitCode.InvalidInput;   // nobody can answer a prompt in a pipeline
+}
+
+return AnsiConsole.Confirm($"Delete user {userId}?", defaultValue: false) ? null : ExitCode.Cancelled;
+```
+
 ## 12. Cancellation
 
 Every `DoExecute` / `DoExecuteAsync` receives a `CancellationToken`. Forward it — into service
@@ -719,3 +756,8 @@ dotnet test samples/SampleApp/Ploch.CommandLine.Spectre.SampleApp.slnx -p:UsePlo
 See [`samples/SampleApp/README.md`](../samples/SampleApp/README.md) for the full command tour and
 for the difference between the standalone (NuGet) and in-repository (project reference) build
 modes.
+
+If you copy that switching trick into a sample of your own, put the conditional import in
+`Directory.Build.targets` rather than `Directory.Build.props`: props is evaluated before the project
+body, so `<PackageReference Remove="..." />` would have nothing to remove and the project would end
+up with both a package reference and a project reference to every library.

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,8 +1,14 @@
-# Ploch.Commandline Samples
+# Ploch.CommandLine Samples
 
 ## Overview
 
-This folder contains samples for the [Ploch.Commandline](../README.md) library.
+This folder contains samples for the [Ploch.CommandLine](../README.md) libraries.
 
 ## Samples
 
+| Sample | Description |
+|---|---|
+| [SampleApp](SampleApp/README.md) | A complete CLI built on `Ploch.CommandLine.Spectre`: multi-level sub-commands, DI and configuration, FluentValidation, token expansion, Serilog, use cases and exit codes. |
+
+New to the libraries? The [Getting Started guide](../docs/GETTING_STARTED.md) builds the same
+features step by step from an empty project.

--- a/samples/SampleApp/Directory.Build.props
+++ b/samples/SampleApp/Directory.Build.props
@@ -1,0 +1,27 @@
+<Project>
+  <!-- This SampleApp is a standalone project that demonstrates how external consumers
+       use the Ploch.CommandLine.Spectre libraries. It must NOT import parent Directory.Build.props
+       or reference any files outside samples/SampleApp/. -->
+  <PropertyGroup>
+    <TargetFrameworkVersion>net10.0</TargetFrameworkVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>$(MSBuildProjectName.EndsWith('Tests'))</IsTestProject>
+    <!-- SA1106: False positive on primary constructor syntax -->
+    <!-- SA1516: False positive on top-level statements -->
+    <!-- SA1600/CS1591: Missing XML documentation in samples/tests -->
+    <NoWarn>$(NoWarn);SA1106;SA1516;SA1600;SA1601;SA1633;CS1591;CC0097;CA1860;S3267;S125</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(IsTestProject)">
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <!-- When building as part of the main Ploch.CommandLine solution, switch from
+       PackageReference to ProjectReference for Ploch libraries.
+       Usage: dotnet build -p:UsePlochProjectReferences=true -->
+  <Import Project="ProjectReferences.props"
+          Condition="'$(UsePlochProjectReferences)' == 'true'" />
+</Project>

--- a/samples/SampleApp/Directory.Build.props
+++ b/samples/SampleApp/Directory.Build.props
@@ -18,10 +18,4 @@
   <PropertyGroup Condition="$(IsTestProject)">
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
-
-  <!-- When building as part of the main Ploch.CommandLine solution, switch from
-       PackageReference to ProjectReference for Ploch libraries.
-       Usage: dotnet build -p:UsePlochProjectReferences=true -->
-  <Import Project="ProjectReferences.props"
-          Condition="'$(UsePlochProjectReferences)' == 'true'" />
 </Project>

--- a/samples/SampleApp/Directory.Build.targets
+++ b/samples/SampleApp/Directory.Build.targets
@@ -1,0 +1,12 @@
+<Project>
+  <!-- When building as part of the main Ploch.CommandLine solution, switch from PackageReference to
+       ProjectReference for the Ploch libraries.
+       Usage: dotnet build -p:UsePlochProjectReferences=true
+
+       This import lives in Directory.Build.targets, not Directory.Build.props, on purpose:
+       Directory.Build.props is evaluated BEFORE the project body, so the <PackageReference Remove="..." />
+       items in ProjectReferences.props would have nothing to remove and both reference kinds would
+       survive. Directory.Build.targets is evaluated AFTER the project body, so the removal works. -->
+  <Import Project="ProjectReferences.props"
+          Condition="'$(UsePlochProjectReferences)' == 'true'" />
+</Project>

--- a/samples/SampleApp/Directory.Packages.props
+++ b/samples/SampleApp/Directory.Packages.props
@@ -1,0 +1,78 @@
+<Project>
+  <!-- This SampleApp is a standalone project that demonstrates how external consumers
+       use the Ploch.CommandLine.Spectre libraries. It must NOT import parent Directory.Packages.props.
+       All package versions are defined here, exactly as an external consumer would. -->
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageFloatingVersionsEnabled>true</CentralPackageFloatingVersionsEnabled>
+    <!-- Transitive pinning lets the Microsoft.Bcl.AsyncInterfaces entry below resolve the
+         assembly-version conflict between xunit.v3.common (6.0.0) and the .NET 10 extension
+         libraries (10.0.5) without adding a direct reference nobody in the sample uses. -->
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- Set this to the published version of Ploch packages.
+         These are used in standalone mode (PackageReference).
+         When UsePlochProjectReferences=true, ProjectReferences.props removes
+         these PackageReferences and replaces them with ProjectReferences. -->
+    <PlochPackagesVersion>0.0.1-prerelease</PlochPackagesVersion>
+  </PropertyGroup>
+
+  <ItemGroup Label="Ploch packages">
+    <PackageVersion Include="Ploch.CommandLine.Spectre" Version="$(PlochPackagesVersion)" />
+    <PackageVersion Include="Ploch.CommandLine.Spectre.FluentValidation" Version="$(PlochPackagesVersion)" />
+    <PackageVersion Include="Ploch.CommandLine.Spectre.Serilog" Version="$(PlochPackagesVersion)" />
+    <PackageVersion Include="Ploch.CommandLine.UseCases" Version="$(PlochPackagesVersion)" />
+    <PackageVersion Include="Ploch.Common" Version="2.0.1" />
+    <PackageVersion Include="Ploch.Common.DependencyInjection" Version="2.0.1" />
+  </ItemGroup>
+
+  <ItemGroup Label="Spectre.Console">
+    <PackageVersion Include="Spectre.Console" Version="0.54.0" />
+    <PackageVersion Include="Spectre.Console.Cli" Version="0.53.1" />
+    <PackageVersion Include="Spectre.Console.Analyzer" Version="1.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Label="Validation &amp; Architecture">
+    <PackageVersion Include="FluentValidation" Version="12.1.0" />
+    <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.0" />
+    <PackageVersion Include="Ardalis.Result" Version="10.1.0" />
+  </ItemGroup>
+
+  <ItemGroup Label="Microsoft Extensions &amp; Logging">
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
+    <PackageVersion Include="Serilog" Version="4.3.0" />
+    <PackageVersion Include="Serilog.Extensions.Hosting" Version="10.0.0" />
+    <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0" />
+    <PackageVersion Include="Serilog.Settings.Configuration" Version="10.0.0" />
+    <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
+    <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
+    <PackageVersion Include="Serilog.Sinks.SpectreConsole" Version="0.3.3" />
+  </ItemGroup>
+
+  <ItemGroup Label="Transitive pins">
+    <!-- xunit.v3.common pulls 6.0.0; everything else unifies on 10.0.5. Pinned so the test
+         project does not build with an unresolved binding conflict (MSB3277). -->
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.5" />
+  </ItemGroup>
+
+  <ItemGroup Label="Testing">
+    <PackageVersion Include="AutoFixture" Version="4.18.1" />
+    <PackageVersion Include="AutoFixture.AutoMoq" Version="4.18.1" />
+    <PackageVersion Include="AutoFixture.Xunit3" Version="4.19.0" />
+    <PackageVersion Include="FluentAssertions" Version="8.10.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
+  </ItemGroup>
+</Project>

--- a/samples/SampleApp/Ploch.CommandLine.Spectre.SampleApp.slnx
+++ b/samples/SampleApp/Ploch.CommandLine.Spectre.SampleApp.slnx
@@ -1,0 +1,8 @@
+<Solution>
+  <Folder Name="/src/">
+    <Project Path="src/SampleApp/Ploch.CommandLine.Spectre.SampleApp.csproj" />
+  </Folder>
+  <Folder Name="/tests/">
+    <Project Path="tests/SampleApp.Tests/Ploch.CommandLine.Spectre.SampleApp.Tests.csproj" />
+  </Folder>
+</Solution>

--- a/samples/SampleApp/ProjectReferences.props
+++ b/samples/SampleApp/ProjectReferences.props
@@ -1,0 +1,28 @@
+<Project>
+  <!-- This file is imported ONLY when building the SampleApp as part of the main
+       Ploch.CommandLine solution, to validate that sample code compiles against the current
+       library source. It replaces Ploch NuGet PackageReferences with ProjectReferences.
+
+       Triggered by: dotnet build -p:UsePlochProjectReferences=true -->
+
+  <!-- Remove all Ploch PackageReferences (they will be replaced by ProjectReferences) -->
+  <ItemGroup>
+    <PackageReference Remove="Ploch.CommandLine.Spectre" />
+    <PackageReference Remove="Ploch.CommandLine.Spectre.FluentValidation" />
+    <PackageReference Remove="Ploch.CommandLine.Spectre.Serilog" />
+    <PackageReference Remove="Ploch.CommandLine.UseCases" />
+    <PackageReference Remove="Ploch.Common" />
+    <PackageReference Remove="Ploch.Common.DependencyInjection" />
+  </ItemGroup>
+
+  <!-- Add ProjectReferences to the library source projects.
+       Paths are anchored to this file's location (samples/SampleApp/) via MSBuildThisFileDirectory. -->
+  <ItemGroup>
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\src\Spectre\CommandLine.Spectre\Ploch.CommandLine.Spectre.csproj" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\src\Spectre\CommandLine.Spectre.FluentValidation\Ploch.CommandLine.Spectre.FluentValidation.csproj" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\src\Spectre\CommandLine.Spectre.Serilog\Ploch.CommandLine.Spectre.Serilog.csproj" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\src\Spectre\CommandLine.UseCases\Ploch.CommandLine.UseCases.csproj" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\..\ploch-common\src\Common\Ploch.Common.csproj" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\..\ploch-common\src\Common.DependencyInjection\Ploch.Common.DependencyInjection.csproj" />
+  </ItemGroup>
+</Project>

--- a/samples/SampleApp/README.md
+++ b/samples/SampleApp/README.md
@@ -33,7 +33,9 @@ plain `dotnet build` fails at restore. Use `-p:UsePlochProjectReferences=true`, 
 CI runs, so the sample cannot drift away from the libraries.
 
 The switch lives in [`ProjectReferences.props`](ProjectReferences.props), imported conditionally by
-[`Directory.Build.props`](Directory.Build.props).
+[`Directory.Build.targets`](Directory.Build.targets) — **targets**, not props: `Directory.Build.props`
+is evaluated before the project body, so the `<PackageReference Remove="..." />` items would have
+nothing to remove and both reference kinds would survive.
 
 ## Running it
 
@@ -175,13 +177,33 @@ Unsupported format 'xml'. Supported formats: table, compact.
 [exit code 2]
 ```
 
-`user delete` shows `ILogger<T>` alongside `IOutput` — the console line is for the user, the log
-entry for whoever reads the log afterwards:
+`user delete` is destructive, so it confirms first: it prompts on an interactive console, and on a
+non-interactive one (a pipeline, a redirected stream) it refuses and tells you how to proceed.
 
 ```text
-$ sample user delete 99
+$ sample user delete 1
 
-Deleting user with ID: 99 (force: False)...
+Refusing to delete user 1 without confirmation. Re-run with --force.
+
+[exit code 2]
+```
+
+```text
+$ sample user delete 1 --force
+
+Deleting user with ID: 1 (force: True)...
+User 1 deleted successfully.
+
+[exit code 0]
+```
+
+It also shows `ILogger<T>` alongside `IOutput` — the console line is for the user, the log entry for
+whoever reads the log afterwards:
+
+```text
+$ sample user delete 99 --force
+
+Deleting user with ID: 99 (force: True)...
 User with ID 99 was not found.
 
 [exit code 1]
@@ -226,6 +248,27 @@ $ sample config get SampleAppSettings:Environment
 SampleAppSettings:Environment: Development
 ```
 
+`config set` demonstrates two positional arguments plus an option constrained to a set of values.
+It previews the change rather than persisting it — the sample has no writable configuration store,
+and saying otherwise would be a lie the next `config get` would expose:
+
+```text
+$ sample config set SampleAppSettings:MaxBatchSize 250
+
+Would set 'SampleAppSettings:MaxBatchSize' = '250' in the 'user' scope.
+Preview only - this sample has no writable configuration store, so nothing is persisted.
+
+[exit code 0]
+```
+
+```text
+$ sample config set SampleAppSettings:MaxBatchSize 250 -s machine
+
+Unsupported scope 'machine'. Supported scopes: user, system.
+
+[exit code 2]
+```
+
 `ConfigShowCommand` renders an **allow-list** of sections rather than `configuration.GetChildren()`.
 The host adds an environment-variable provider, so enumerating the configuration root would print
 every environment variable of the process — tokens and API keys included. The allow-list is the
@@ -251,6 +294,53 @@ Saved result to: ./out-2026-08-22/result.dat
 `OutputPath` carries `[SupportsTokens]`; the `CommandArgumentsRootProcessor` rewrites `{date}`
 before the command body sees the value. The simulated work honours the `CancellationToken`, so
 Ctrl+C ends the command with `ExitCode.Cancelled` (130).
+
+`file report` checks its input before reporting on it, and reports what it actually found:
+
+```text
+$ sample file report dataset.csv -t "Daily Report - {date}"
+
+╭─Daily Report - 2026-08-22─────────────────────────────────────────────────╮
+│ Report Title: Daily Report - 2026-08-22                                   │
+│ Source File: C:\Users\krzys\AppData\Local\Temp\wt9-sample-run\dataset.csv │
+│ Size: 17 bytes                                                            │
+│ Last Modified: 2026-08-22 13:01:07 UTC                                    │
+│ Status: Analysed                                                          │
+│ Generated: 2026-08-22 13:01:07 UTC                                        │
+╰───────────────────────────────────────────────────────────────────────────╯
+
+[exit code 0]
+```
+
+```text
+$ sample file report missing.csv
+
+File 'missing.csv' was not found.
+
+[exit code 2]
+```
+
+### Escaping user input in markup
+
+Every value that reaches a `Table` cell, a `Panel`, a `Tree` node or a `Markup` is parsed as Spectre
+markup. A user name, a file path or a configuration value containing `[` would either throw during
+rendering or inject formatting, so the sample escapes each of them with `Markup.Escape`:
+
+```text
+$ sample user add "Alice [Admin] Smith" -e alice@example.com -r Administrator
+
+╭─User Created Successfully────────╮
+│ User ID: 4                       │
+│ Name: Alice [Admin] Smith        │
+│ Email: alice@example.com         │
+│ Role: Administrator              │
+│ Active: Yes                      │
+│ Created: 2026-08-22 12:59:47 UTC │
+╰──────────────────────────────────╯
+```
+
+`IOutput.MarkupLineInterpolated` escapes its interpolation holes for you; a `Markup` built from an
+ordinary interpolated string does not.
 
 ### `project` — use cases and `Ardalis.Result`
 
@@ -280,6 +370,27 @@ Use case failed: A project with name 'SpectreDemo' already exists.
 
 `ProjectCreateCommand` derives from `UseCaseAsyncCommand<,,,>` and implements one method,
 `CreateRequest`. Echoing the settings and rendering the result are inherited.
+
+`project export` writes a real artefact — a success result from a use case that produced nothing
+would be a lie:
+
+```text
+$ sample project export SpectreDemo -o "./exports-{date}"
+
+Starting use case ExportProjectUseCase
+Settings:
+Name: SpectreDemo
+OutputPath: ./exports-2026-08-22
+Use case completed successfully.
+
+$ cat exports-2026-08-22/SpectreDemo.json
+{
+  "Name": "SpectreDemo",
+  "Description": "Demo project for Spectre Console CLI",
+  "Template": "Console",
+  "CreatedAt": "2026-08-12T13:01:26.0404929Z"
+}
+```
 
 ## Exit codes
 
@@ -316,6 +427,7 @@ samples/SampleApp/
     Services/                              # In-memory domain services and models
   tests/SampleApp.Tests/
     Commands/                              # Command unit tests (mocked dependencies)
+    UseCases/                              # Use case tests, including the written export artefact
     Validation/                            # FluentValidation rule tests
 ```
 
@@ -325,5 +437,5 @@ samples/SampleApp/
 dotnet test samples/SampleApp/Ploch.CommandLine.Spectre.SampleApp.slnx -p:UsePlochProjectReferences=true
 ```
 
-20 tests: command exit codes, token expansion, cancellation handling, use case invocation and
-validator rules. They use xUnit v3, FluentAssertions and Moq.
+28 tests: command exit codes, token expansion, cancellation handling, input validation, the export
+artefact, use case invocation and validator rules. They use xUnit v3, FluentAssertions and Moq.

--- a/samples/SampleApp/README.md
+++ b/samples/SampleApp/README.md
@@ -1,0 +1,329 @@
+# Ploch.CommandLine.Spectre — Sample Application
+
+A complete, runnable CLI built on the `Ploch.CommandLine.Spectre` packages. It exists to be read
+and run: every feature of the library appears here in a form you can execute and compare against
+the output below.
+
+Building a CLI of your own? Start with the step-by-step
+[Getting Started guide](../../docs/GETTING_STARTED.md) — it walks through the same features from an
+empty project. This README is the tour of what is already here.
+
+Packages exercised:
+
+- `Ploch.CommandLine.Spectre` — `AppBuilder`, command base classes, `IOutput`, exit codes, tokens
+- `Ploch.CommandLine.Spectre.FluentValidation` — settings validation
+- `Ploch.CommandLine.Spectre.Serilog` — logging
+- `Ploch.CommandLine.UseCases` — use cases with `Ardalis.Result`
+
+## Build modes — read this first
+
+The sample is deliberately **standalone**: it references the Ploch libraries as
+`PackageReference`, exactly as an external consumer would, and it has its own
+`Directory.Build.props` and `Directory.Packages.props` so it does not inherit anything from the
+repository it lives in.
+
+| Mode | Command | What it does |
+|---|---|---|
+| Standalone (default) | `dotnet build` | Restores `Ploch.*` from NuGet, as a consumer would |
+| In-repository | `dotnet build -p:UsePlochProjectReferences=true` | Swaps those packages for `ProjectReference`s to the library sources in this repository |
+
+**The default mode cannot restore yet.** The `Ploch.CommandLine.*` packages have not been published
+(that is [issue #7](https://github.com/mrploch/ploch-commandline/issues/7)); until they are, a
+plain `dotnet build` fails at restore. Use `-p:UsePlochProjectReferences=true`, which is also what
+CI runs, so the sample cannot drift away from the libraries.
+
+The switch lives in [`ProjectReferences.props`](ProjectReferences.props), imported conditionally by
+[`Directory.Build.props`](Directory.Build.props).
+
+## Running it
+
+All commands below are run from the repository root.
+
+```bash
+dotnet build samples/SampleApp/Ploch.CommandLine.Spectre.SampleApp.slnx -p:UsePlochProjectReferences=true
+dotnet test  samples/SampleApp/Ploch.CommandLine.Spectre.SampleApp.slnx -p:UsePlochProjectReferences=true
+dotnet run --project samples/SampleApp/src/SampleApp -p:UsePlochProjectReferences=true -- --help
+```
+
+`dotnet run` passes everything after `--` to the application. The listings below drop the FIGlet
+banner the application prints before each command, and were captured with `NO_COLOR=1`.
+
+### The command tree
+
+```text
+$ sample --help
+
+USAGE:
+    sample [OPTIONS] <COMMAND>
+
+EXAMPLES:
+    sample info
+    sample info -d
+    sample user add Alice Smith -e alice@example.com -r Administrator
+    sample user list
+    sample user list -a -f compact
+
+OPTIONS:
+    -h, --help    Prints help information
+
+COMMANDS:
+    info       Display system, application, and host runtime information
+    user       Manage user accounts and profile data
+    config     Inspect and manage application configuration settings
+    file       File processing and report generation utilities
+    project    Project operations powered by Clean Architecture use cases and
+               Ardalis.Result
+```
+
+Each branch has its own help — `sample user --help`, `sample config --help`, and so on.
+
+### `info` — a synchronous command
+
+```text
+$ sample info
+
+=== Application & System Information ===
+
+╭──────────────────────┬────────────────────────────────────────────╮
+│ Property             │ Value                                      │
+├──────────────────────┼────────────────────────────────────────────┤
+│ Application Name     │ Ploch.CommandLine.Spectre Sample App       │
+│ Framework            │ .NET 10.0.11                               │
+│ OS Description       │ Microsoft Windows 10.0.26200               │
+│ Process Architecture │ X64                                        │
+│ Current Directory    │ C:\DevNet\my\mrploch\ploch-commandline-wt9 │
+│ Machine Name         │ KPLOCH-MSI                                 │
+│ Environment Setting  │ Development                                │
+╰──────────────────────┴────────────────────────────────────────────╯
+
+Command completed successfully.
+```
+
+`info -d` adds a diagnostics panel. Implementation: `Commands/Common/InfoCommand.cs`, deriving from
+`AppCommand<TSettings>`.
+
+### `user` — asynchronous commands, DI and validation
+
+```text
+$ sample user list
+
+Executing command UserListCommandSettings
+
+Processing arguments...
+Retrieving users (active only: False)...
+                                Registered Users
+╭────┬───────────────┬─────────────────┬───────────────┬──────────┬────────────╮
+│ ID │ Name          │ Email           │ Role          │ Status   │ Created At │
+├────┼───────────────┼─────────────────┼───────────────┼──────────┼────────────┤
+│ 1  │ Alice Smith   │ alice.smith@exa │ Administrator │ Active   │ 2026-07-23 │
+│    │               │ mple.com        │               │          │            │
+│ 2  │ Bob Jones     │ bob.jones@examp │ Developer     │ Active   │ 2026-08-07 │
+│    │               │ le.com          │               │          │            │
+│ 3  │ Charlie Brown │ charlie.brown@e │ Contributor   │ Inactive │ 2026-08-17 │
+│    │               │ xample.com      │               │          │            │
+╰────┴───────────────┴─────────────────┴───────────────┴──────────┴────────────╯
+
+Total users: 3
+```
+
+```text
+$ sample user add "Alice Smith" -e alice@example.com -r Administrator
+
+Creating new user account for Alice Smith...
+╭─User Created Successfully────────╮
+│ User ID: 4                       │
+│ Name: Alice Smith                │
+│ Email: alice@example.com         │
+│ Role: Administrator              │
+│ Active: Yes                      │
+│ Created: 2026-08-22 12:37:59 UTC │
+╰──────────────────────────────────╯
+```
+
+All three `user` commands inherit `GlobalSettings`, so `-v|--verbose` is declared once and shows up
+in each of their help screens:
+
+```text
+$ sample user list -v -f compact -a
+
+Verbose: format='compact', active only='True'.
+Retrieving users (active only: True)...
+[1] Alice Smith <alice.smith@example.com> (Administrator) - Active: True
+[2] Bob Jones <bob.jones@example.com> (Developer) - Active: True
+
+Total users: 2
+```
+
+FluentValidation rejects bad input before the command body runs:
+
+```text
+$ sample user add "A" -e "invalid-email"
+
+Error: User name must be at least 2 characters long.
+A valid email address must be provided.
+
+[exit code -1]
+```
+
+A value the command itself rejects returns `ExitCode.InvalidInput` instead:
+
+```text
+$ sample user list -f xml
+
+Unsupported format 'xml'. Supported formats: table, compact.
+
+[exit code 2]
+```
+
+`user delete` shows `ILogger<T>` alongside `IOutput` — the console line is for the user, the log
+entry for whoever reads the log afterwards:
+
+```text
+$ sample user delete 99
+
+Deleting user with ID: 99 (force: False)...
+User with ID 99 was not found.
+
+[exit code 1]
+```
+
+```text
+$ cat logs/sample.log
+2026-08-22 14:36:16.690 +02:00 [WRN] [UserDeleteCommand] Delete requested for unknown user 99
+```
+
+### `config` — configuration
+
+```text
+$ sample config show
+
+Application Configuration Settings
+
+Configuration
+├── SampleAppSettings
+│   ├── DefaultOutputDirectory
+│   │   └── Value: ./output
+│   ├── EnableDiagnostics
+│   │   └── Value: True
+│   ├── Environment
+│   │   └── Value: Development
+│   └── MaxBatchSize
+│       └── Value: 100
+└── Serilog
+    └── MinimumLevel
+        ├── Default
+        │   └── Value: Information
+        └── Override
+            ├── Microsoft
+            │   └── Value: Warning
+            └── System
+                └── Value: Warning
+```
+
+```text
+$ sample config get SampleAppSettings:Environment
+
+SampleAppSettings:Environment: Development
+```
+
+`ConfigShowCommand` renders an **allow-list** of sections rather than `configuration.GetChildren()`.
+The host adds an environment-variable provider, so enumerating the configuration root would print
+every environment variable of the process — tokens and API keys included. The allow-list is the
+point of the example.
+
+`Program.cs` also pins the configuration base path to `AppContext.BaseDirectory`, so the settings
+load no matter which directory the tool is invoked from.
+
+### `file` — token expansion
+
+```text
+$ sample file process dataset.csv -o "./out-{date}/result.dat"
+
+Processing File: dataset.csv
+Resolved Output Path (with tokens replaced): ./out-2026-08-22/result.dat
+Backup enabled: True
+
+Processing file content...
+File processed successfully!
+Saved result to: ./out-2026-08-22/result.dat
+```
+
+`OutputPath` carries `[SupportsTokens]`; the `CommandArgumentsRootProcessor` rewrites `{date}`
+before the command body sees the value. The simulated work honours the `CancellationToken`, so
+Ctrl+C ends the command with `ExitCode.Cancelled` (130).
+
+### `project` — use cases and `Ardalis.Result`
+
+```text
+$ sample project create MicroserviceDemo -d "Cloud native backend" -t WebAPI
+
+Starting use case CreateProjectUseCase
+Settings:
+Name: MicroserviceDemo
+Description: Cloud native backend
+Template: WebAPI
+Use case completed successfully.
+```
+
+```text
+$ sample project create SpectreDemo
+
+Starting use case CreateProjectUseCase
+Settings:
+Name: SpectreDemo
+Description: Sample project
+Template: Console
+Use case failed: A project with name 'SpectreDemo' already exists.
+
+[exit code 1]
+```
+
+`ProjectCreateCommand` derives from `UseCaseAsyncCommand<,,,>` and implements one method,
+`CreateRequest`. Echoing the settings and rendering the result are inherited.
+
+## Exit codes
+
+| Code | Source | Meaning |
+|---|---|---|
+| 0 | `ExitCode.Success` | The command completed |
+| 1 | `ExitCode.Error` | The command ran and failed |
+| 2 | `ExitCode.InvalidInput` | The command rejected its input |
+| 130 | `ExitCode.Cancelled` | Cancellation was requested (128 + SIGINT) |
+| -1 | `Spectre.Console.Cli` | The command line could not be bound or validated |
+
+## Development conveniences
+
+`DEV_RUNTIME_CONSOLE_EXIT_PAUSE=true` makes the application wait for Enter before exiting — useful
+when launching from an IDE.
+
+## Layout
+
+```
+samples/SampleApp/
+  Directory.Build.props                    # Standalone build settings; imports ProjectReferences.props on demand
+  Directory.Packages.props                 # All package versions, as an external consumer would declare them
+  ProjectReferences.props                  # In-repository mode: PackageReference -> ProjectReference
+  Ploch.CommandLine.Spectre.SampleApp.slnx
+  src/SampleApp/
+    Program.cs                             # AppBuilder, DI, configuration, Serilog, command tree
+    appsettings.json
+    Commands/
+      Common/                              # GlobalSettings, InfoCommand (AppCommand)
+      Users/                               # AsyncAppCommand + FluentValidation validators
+      Config/                              # IConfiguration-driven commands
+      Files/                               # [SupportsTokens] and cancellation
+      Projects/                            # UseCaseAsyncCommand + UseCases/
+    Services/                              # In-memory domain services and models
+  tests/SampleApp.Tests/
+    Commands/                              # Command unit tests (mocked dependencies)
+    Validation/                            # FluentValidation rule tests
+```
+
+## Tests
+
+```bash
+dotnet test samples/SampleApp/Ploch.CommandLine.Spectre.SampleApp.slnx -p:UsePlochProjectReferences=true
+```
+
+20 tests: command exit codes, token expansion, cancellation handling, use case invocation and
+validator rules. They use xUnit v3, FluentAssertions and Moq.

--- a/samples/SampleApp/src/SampleApp/Commands/Common/GlobalSettings.cs
+++ b/samples/SampleApp/src/SampleApp/Commands/Common/GlobalSettings.cs
@@ -1,0 +1,27 @@
+using System.ComponentModel;
+using Spectre.Console.Cli;
+
+namespace Ploch.CommandLine.Spectre.SampleApp.Commands.Common;
+
+/// <summary>
+///     Options shared by every command in the <c>user</c> branch. Settings classes inherit from a common
+///     base so an option is declared once and appears in the help of each command that derives from it.
+/// </summary>
+public class GlobalSettings : CommandSettings
+{
+    [CommandOption("-v|--verbose")]
+    [Description("Enable verbose console output.")]
+    [DefaultValue(false)]
+    public bool Verbose { get; set; }
+}
+
+/// <summary>
+///     Settings for the info command.
+/// </summary>
+public class InfoCommandSettings : CommandSettings
+{
+    [CommandOption("-d|--diagnostics")]
+    [Description("Display extended runtime and host diagnostics.")]
+    [DefaultValue(false)]
+    public bool ShowDiagnostics { get; set; }
+}

--- a/samples/SampleApp/src/SampleApp/Commands/Common/InfoCommand.cs
+++ b/samples/SampleApp/src/SampleApp/Commands/Common/InfoCommand.cs
@@ -15,6 +15,7 @@ public class InfoCommand(ICommandSettingsValidator<InfoCommandSettings> validato
                          IOutput output,
                          IConfiguration configuration) : AppCommand<InfoCommandSettings>(validator, exceptionHandler)
 {
+    /// <inheritdoc />
     protected override ExitCode DoExecute(CommandContext? context, InfoCommandSettings settings, CancellationToken cancellationToken)
     {
         output.MarkupLineInterpolated($"[bold cyan]=== Application & System Information ===[/]");
@@ -24,28 +25,32 @@ public class InfoCommand(ICommandSettingsValidator<InfoCommandSettings> validato
         table.AddColumn("[yellow]Property[/]");
         table.AddColumn("[green]Value[/]");
 
+        // Table cells are parsed as markup, so every value that did not come from this source file
+        // is escaped. A path or machine name containing '[' would otherwise break the render.
         table.AddRow("Application Name", "Ploch.CommandLine.Spectre Sample App");
-        table.AddRow("Framework", RuntimeInformation.FrameworkDescription);
-        table.AddRow("OS Description", RuntimeInformation.OSDescription);
+        table.AddRow("Framework", Markup.Escape(RuntimeInformation.FrameworkDescription));
+        table.AddRow("OS Description", Markup.Escape(RuntimeInformation.OSDescription));
         table.AddRow("Process Architecture", RuntimeInformation.ProcessArchitecture.ToString());
-        table.AddRow("Current Directory", Environment.CurrentDirectory);
-        table.AddRow("Machine Name", Environment.MachineName);
-        table.AddRow("Environment Setting", configuration["SampleAppSettings:Environment"] ?? "Not configured");
+        table.AddRow("Current Directory", Markup.Escape(Environment.CurrentDirectory));
+        table.AddRow("Machine Name", Markup.Escape(Environment.MachineName));
+        table.AddRow("Environment Setting", Markup.Escape(configuration["SampleAppSettings:Environment"] ?? "Not configured"));
 
-        AnsiConsole.Write(table);
+        // Rendered through IOutput rather than the static AnsiConsole, so the command stays testable
+        // with a mocked IOutput and honours whatever console the host configured.
+        output.Write(table);
 
         if (settings.ShowDiagnostics)
         {
             output.WriteLine();
-            var panel = new Panel(new Markup("[dim]Memory Working Set:[/] [white]" +
-                                             (Environment.WorkingSet / 1024 / 1024) + " MB[/]\n" +
-                                             "[dim]Thread Count:[/] [white]" + Environment.ProcessorCount + " logical cores[/]\n" +
-                                             "[dim]Serilog MinLevel:[/] [white]" + (configuration["Serilog:MinimumLevel:Default"] ?? "Information") + "[/]"))
+            var serilogLevel = Markup.Escape(configuration["Serilog:MinimumLevel:Default"] ?? "Information");
+            var panel = new Panel(new Markup($"[dim]Memory Working Set:[/] [white]{Environment.WorkingSet / 1024 / 1024} MB[/]\n" +
+                                             $"[dim]Thread Count:[/] [white]{Environment.ProcessorCount} logical cores[/]\n" +
+                                             $"[dim]Serilog MinLevel:[/] [white]{serilogLevel}[/]"))
             {
                 Header = new PanelHeader("[bold yellow]Diagnostics[/]"),
                 Border = BoxBorder.Double
             };
-            AnsiConsole.Write(panel);
+            output.Write(panel);
         }
 
         output.WriteLine();

--- a/samples/SampleApp/src/SampleApp/Commands/Common/InfoCommand.cs
+++ b/samples/SampleApp/src/SampleApp/Commands/Common/InfoCommand.cs
@@ -1,0 +1,56 @@
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.Configuration;
+using Ploch.CommandLine.Spectre.Commands;
+using Ploch.CommandLine.Spectre.Output;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Ploch.CommandLine.Spectre.SampleApp.Commands.Common;
+
+/// <summary>
+///     Synchronous command demonstrating <see cref="AppCommand{TSettings}" /> and rich output display.
+/// </summary>
+public class InfoCommand(ICommandSettingsValidator<InfoCommandSettings> validator,
+                         IExceptionHandler exceptionHandler,
+                         IOutput output,
+                         IConfiguration configuration) : AppCommand<InfoCommandSettings>(validator, exceptionHandler)
+{
+    protected override ExitCode DoExecute(CommandContext? context, InfoCommandSettings settings, CancellationToken cancellationToken)
+    {
+        output.MarkupLineInterpolated($"[bold cyan]=== Application & System Information ===[/]");
+        output.WriteLine();
+
+        var table = new Table().Border(TableBorder.Rounded);
+        table.AddColumn("[yellow]Property[/]");
+        table.AddColumn("[green]Value[/]");
+
+        table.AddRow("Application Name", "Ploch.CommandLine.Spectre Sample App");
+        table.AddRow("Framework", RuntimeInformation.FrameworkDescription);
+        table.AddRow("OS Description", RuntimeInformation.OSDescription);
+        table.AddRow("Process Architecture", RuntimeInformation.ProcessArchitecture.ToString());
+        table.AddRow("Current Directory", Environment.CurrentDirectory);
+        table.AddRow("Machine Name", Environment.MachineName);
+        table.AddRow("Environment Setting", configuration["SampleAppSettings:Environment"] ?? "Not configured");
+
+        AnsiConsole.Write(table);
+
+        if (settings.ShowDiagnostics)
+        {
+            output.WriteLine();
+            var panel = new Panel(new Markup("[dim]Memory Working Set:[/] [white]" +
+                                             (Environment.WorkingSet / 1024 / 1024) + " MB[/]\n" +
+                                             "[dim]Thread Count:[/] [white]" + Environment.ProcessorCount + " logical cores[/]\n" +
+                                             "[dim]Serilog MinLevel:[/] [white]" + (configuration["Serilog:MinimumLevel:Default"] ?? "Information") + "[/]"))
+            {
+                Header = new PanelHeader("[bold yellow]Diagnostics[/]"),
+                Border = BoxBorder.Double
+            };
+            AnsiConsole.Write(panel);
+        }
+
+        output.WriteLine();
+        output.MarkupLineInterpolated($"[green]Command completed successfully.[/]");
+
+        return ExitCode.Success;
+    }
+}

--- a/samples/SampleApp/src/SampleApp/Commands/Config/ConfigGetCommand.cs
+++ b/samples/SampleApp/src/SampleApp/Commands/Config/ConfigGetCommand.cs
@@ -1,0 +1,31 @@
+using Microsoft.Extensions.Configuration;
+using Ploch.CommandLine.Spectre.Commands;
+using Ploch.CommandLine.Spectre.Output;
+using Spectre.Console.Cli;
+
+namespace Ploch.CommandLine.Spectre.SampleApp.Commands.Config;
+
+/// <summary>
+///     Command to get a configuration value by key.
+/// </summary>
+public class ConfigGetCommand(ICommandSettingsValidator<ConfigGetCommandSettings> validator,
+                              IExceptionHandler exceptionHandler,
+                              IOutput output,
+                              IConfiguration configuration) : AppCommand<ConfigGetCommandSettings>(validator, exceptionHandler)
+{
+    protected override ExitCode DoExecute(CommandContext? context, ConfigGetCommandSettings settings, CancellationToken cancellationToken)
+    {
+        var value = configuration[settings.Key];
+
+        if (value is null)
+        {
+            output.MarkupLineInterpolated($"[yellow]Configuration key '{settings.Key}' not found.[/]");
+
+            return ExitCode.Error;
+        }
+
+        output.MarkupLineInterpolated($"[cyan]{settings.Key}[/]: [bold green]{value}[/]");
+
+        return ExitCode.Success;
+    }
+}

--- a/samples/SampleApp/src/SampleApp/Commands/Config/ConfigSetCommand.cs
+++ b/samples/SampleApp/src/SampleApp/Commands/Config/ConfigSetCommand.cs
@@ -1,0 +1,21 @@
+using Ploch.CommandLine.Spectre.Commands;
+using Ploch.CommandLine.Spectre.Output;
+using Spectre.Console.Cli;
+
+namespace Ploch.CommandLine.Spectre.SampleApp.Commands.Config;
+
+/// <summary>
+///     Command to set a configuration value.
+/// </summary>
+public class ConfigSetCommand(ICommandSettingsValidator<ConfigSetCommandSettings> validator,
+                              IExceptionHandler exceptionHandler,
+                              IOutput output) : AppCommand<ConfigSetCommandSettings>(validator, exceptionHandler)
+{
+    protected override ExitCode DoExecute(CommandContext? context, ConfigSetCommandSettings settings, CancellationToken cancellationToken)
+    {
+        output.MarkupLineInterpolated($"[dim]Setting configuration in scope '{settings.Scope}'...[/]");
+        output.MarkupLineInterpolated($"[green]Set '{settings.Key}' = '{settings.Value}' (Scope: {settings.Scope})[/]");
+
+        return ExitCode.Success;
+    }
+}

--- a/samples/SampleApp/src/SampleApp/Commands/Config/ConfigSetCommand.cs
+++ b/samples/SampleApp/src/SampleApp/Commands/Config/ConfigSetCommand.cs
@@ -5,16 +5,32 @@ using Spectre.Console.Cli;
 namespace Ploch.CommandLine.Spectre.SampleApp.Commands.Config;
 
 /// <summary>
-///     Command to set a configuration value.
+///     Command demonstrating multiple positional arguments plus an option with a constrained set of values.
 /// </summary>
+/// <remarks>
+///     The change is previewed, not persisted. The sample has no writable configuration store, and the
+///     configuration providers the host builds (JSON file, environment variables) are read-only, so a
+///     value "set" here could not be observed by <c>config get</c> in the next invocation. Rather than
+///     report a change that did not happen, the command shows what it would write.
+/// </remarks>
 public class ConfigSetCommand(ICommandSettingsValidator<ConfigSetCommandSettings> validator,
                               IExceptionHandler exceptionHandler,
                               IOutput output) : AppCommand<ConfigSetCommandSettings>(validator, exceptionHandler)
 {
+    private static readonly string[] SupportedScopes = ["user", "system"];
+
+    /// <inheritdoc />
     protected override ExitCode DoExecute(CommandContext? context, ConfigSetCommandSettings settings, CancellationToken cancellationToken)
     {
-        output.MarkupLineInterpolated($"[dim]Setting configuration in scope '{settings.Scope}'...[/]");
-        output.MarkupLineInterpolated($"[green]Set '{settings.Key}' = '{settings.Value}' (Scope: {settings.Scope})[/]");
+        if (!SupportedScopes.Contains(settings.Scope, StringComparer.OrdinalIgnoreCase))
+        {
+            output.MarkupLineInterpolated($"[red]Unsupported scope '{settings.Scope}'. Supported scopes: {string.Join(", ", SupportedScopes)}.[/]");
+
+            return ExitCode.InvalidInput;
+        }
+
+        output.MarkupLineInterpolated($"[green]Would set '{settings.Key}' = '{settings.Value}' in the '{settings.Scope}' scope.[/]");
+        output.MarkupLineInterpolated($"[dim]Preview only - this sample has no writable configuration store, so nothing is persisted.[/]");
 
         return ExitCode.Success;
     }

--- a/samples/SampleApp/src/SampleApp/Commands/Config/ConfigSettings.cs
+++ b/samples/SampleApp/src/SampleApp/Commands/Config/ConfigSettings.cs
@@ -1,0 +1,43 @@
+using System.ComponentModel;
+using Spectre.Console.Cli;
+
+namespace Ploch.CommandLine.Spectre.SampleApp.Commands.Config;
+
+/// <summary>
+///     Settings for the config get command.
+/// </summary>
+public class ConfigGetCommandSettings : CommandSettings
+{
+    [CommandArgument(0, "<KEY>")]
+    [Description("The configuration key to retrieve (e.g. 'SampleAppSettings:Environment').")]
+    public string Key { get; set; } = string.Empty;
+}
+
+/// <summary>
+///     Settings for the config set command.
+/// </summary>
+public class ConfigSetCommandSettings : CommandSettings
+{
+    [CommandArgument(0, "<KEY>")]
+    [Description("The configuration key to set.")]
+    public string Key { get; set; } = string.Empty;
+
+    [CommandArgument(1, "<VALUE>")]
+    [Description("The configuration value to set.")]
+    public string Value { get; set; } = string.Empty;
+
+    [CommandOption("-s|--scope <SCOPE>")]
+    [Description("The configuration scope ('user' or 'system').")]
+    [DefaultValue("user")]
+    public string Scope { get; set; } = "user";
+}
+
+/// <summary>
+///     Settings for the config show command.
+/// </summary>
+public class ConfigShowCommandSettings : CommandSettings
+{
+    [CommandOption("-s|--section <SECTION>")]
+    [Description("Filter configuration by section name.")]
+    public string? Section { get; set; }
+}

--- a/samples/SampleApp/src/SampleApp/Commands/Config/ConfigShowCommand.cs
+++ b/samples/SampleApp/src/SampleApp/Commands/Config/ConfigShowCommand.cs
@@ -47,7 +47,7 @@ public class ConfigShowCommand(ICommandSettingsValidator<ConfigShowCommandSettin
                 continue;
             }
 
-            var sectionNode = root.AddNode($"[cyan]{section.Key}[/]");
+            var sectionNode = root.AddNode($"[cyan]{Markup.Escape(section.Key)}[/]");
             AddSectionChildren(sectionNode, section);
             rendered++;
         }
@@ -60,7 +60,7 @@ public class ConfigShowCommand(ICommandSettingsValidator<ConfigShowCommandSettin
             return ExitCode.InvalidInput;
         }
 
-        AnsiConsole.Write(root);
+        output.Write(root);
 
         return ExitCode.Success;
     }
@@ -70,14 +70,16 @@ public class ConfigShowCommand(ICommandSettingsValidator<ConfigShowCommandSettin
         var children = section.GetChildren().ToList();
         if (children.Count == 0 && section.Value != null)
         {
-            parentNode.AddNode($"[dim]Value:[/] [green]{section.Value}[/]");
+            // Keys and values come from JSON and the environment: escape them so a value
+            // containing '[' renders as text instead of being parsed as markup.
+            parentNode.AddNode($"[dim]Value:[/] [green]{Markup.Escape(section.Value)}[/]");
 
             return;
         }
 
         foreach (var child in children)
         {
-            var childNode = parentNode.AddNode($"[white]{child.Key}[/]");
+            var childNode = parentNode.AddNode($"[white]{Markup.Escape(child.Key)}[/]");
             AddSectionChildren(childNode, child);
         }
     }

--- a/samples/SampleApp/src/SampleApp/Commands/Config/ConfigShowCommand.cs
+++ b/samples/SampleApp/src/SampleApp/Commands/Config/ConfigShowCommand.cs
@@ -1,0 +1,84 @@
+using Microsoft.Extensions.Configuration;
+using Ploch.CommandLine.Spectre.Commands;
+using Ploch.CommandLine.Spectre.Output;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Ploch.CommandLine.Spectre.SampleApp.Commands.Config;
+
+/// <summary>
+///     Command to display the application's own configuration, formatted as a tree.
+/// </summary>
+public class ConfigShowCommand(ICommandSettingsValidator<ConfigShowCommandSettings> validator,
+                               IExceptionHandler exceptionHandler,
+                               IOutput output,
+                               IConfiguration configuration) : AppCommand<ConfigShowCommandSettings>(validator, exceptionHandler)
+{
+    /// <summary>
+    ///     The configuration sections this application owns.
+    /// </summary>
+    /// <remarks>
+    ///     Deliberately an allow-list rather than <c>configuration.GetChildren()</c>. The host adds an
+    ///     environment-variable configuration provider, so enumerating the configuration root would print
+    ///     every environment variable of the process — API keys and access tokens included. A CLI that
+    ///     renders configuration must show only the keys it owns.
+    /// </remarks>
+    private static readonly string[] ApplicationSections = ["SampleAppSettings", "Logging", "Serilog"];
+
+    /// <inheritdoc />
+    protected override ExitCode DoExecute(CommandContext? context, ConfigShowCommandSettings settings, CancellationToken cancellationToken)
+    {
+        output.MarkupLineInterpolated($"[bold cyan]Application Configuration Settings[/]");
+        output.WriteLine();
+
+        var root = new Tree("[bold yellow]Configuration[/]");
+        var rendered = 0;
+
+        foreach (var sectionName in ApplicationSections)
+        {
+            if (settings.Section is not null && !sectionName.Contains(settings.Section, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var section = configuration.GetSection(sectionName);
+            if (!section.Exists())
+            {
+                continue;
+            }
+
+            var sectionNode = root.AddNode($"[cyan]{section.Key}[/]");
+            AddSectionChildren(sectionNode, section);
+            rendered++;
+        }
+
+        if (rendered == 0)
+        {
+            output.MarkupLineInterpolated($"[yellow]No configuration section matched '{settings.Section}'.[/]");
+            output.MarkupLineInterpolated($"[dim]Known sections: {string.Join(", ", ApplicationSections)}[/]");
+
+            return ExitCode.InvalidInput;
+        }
+
+        AnsiConsole.Write(root);
+
+        return ExitCode.Success;
+    }
+
+    private static void AddSectionChildren(TreeNode parentNode, IConfigurationSection section)
+    {
+        var children = section.GetChildren().ToList();
+        if (children.Count == 0 && section.Value != null)
+        {
+            parentNode.AddNode($"[dim]Value:[/] [green]{section.Value}[/]");
+
+            return;
+        }
+
+        foreach (var child in children)
+        {
+            var childNode = parentNode.AddNode($"[white]{child.Key}[/]");
+            AddSectionChildren(childNode, child);
+        }
+    }
+}

--- a/samples/SampleApp/src/SampleApp/Commands/Files/FileProcessCommand.cs
+++ b/samples/SampleApp/src/SampleApp/Commands/Files/FileProcessCommand.cs
@@ -1,0 +1,38 @@
+using Ploch.CommandLine.Spectre.Commands;
+using Ploch.CommandLine.Spectre.Output;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Ploch.CommandLine.Spectre.SampleApp.Commands.Files;
+
+/// <summary>
+///     Command demonstrating token replacement via <see cref="SupportsTokensAttribute" /> and progress simulation.
+/// </summary>
+public class FileProcessCommand(CommandArgumentsRootProcessor settingsProcessor,
+                                ICommandSettingsValidator<FileProcessCommandSettings> validator,
+                                IExceptionHandler exceptionHandler,
+                                IOutput output) : AsyncAppCommand<FileProcessCommandSettings>(settingsProcessor, validator, exceptionHandler, output)
+{
+    protected override async Task<ExitCode> DoExecuteAsync(CommandContext context, FileProcessCommandSettings settings, CancellationToken cancellationToken)
+    {
+        Output.MarkupLineInterpolated($"[bold cyan]Processing File:[/] [yellow]{settings.Path}[/]");
+        Output.MarkupLineInterpolated($"[bold cyan]Resolved Output Path (with tokens replaced):[/] [green]{settings.OutputPath}[/]");
+        Output.MarkupLineInterpolated($"[dim]Backup enabled: {settings.Backup}[/]");
+        Output.WriteLine();
+
+        await AnsiConsole.Status()
+                         .Spinner(Spinner.Known.Dots)
+                         .StartAsync("Processing file content...",
+                                     async _ =>
+                                     {
+                                         // Simulated work: the token is honoured so Ctrl+C stops the command
+                                         // instead of waiting for the delay to elapse.
+                                         await Task.Delay(TimeSpan.FromMilliseconds(300), cancellationToken);
+                                     });
+
+        Output.MarkupLineInterpolated($"[bold green]File processed successfully![/]");
+        Output.MarkupLineInterpolated($"Saved result to: [underline]{settings.OutputPath}[/]");
+
+        return ExitCode.Success;
+    }
+}

--- a/samples/SampleApp/src/SampleApp/Commands/Files/FileProcessSettings.cs
+++ b/samples/SampleApp/src/SampleApp/Commands/Files/FileProcessSettings.cs
@@ -1,0 +1,42 @@
+using System.ComponentModel;
+using Ploch.CommandLine.Spectre.Commands;
+using Spectre.Console.Cli;
+
+namespace Ploch.CommandLine.Spectre.SampleApp.Commands.Files;
+
+/// <summary>
+///     Settings for file processing command, demonstrating <see cref="SupportsTokensAttribute" /> token replacement.
+/// </summary>
+public class FileProcessCommandSettings : CommandSettings
+{
+    [CommandArgument(0, "<PATH>")]
+    [Description("Path to the input file to process.")]
+    public string Path { get; set; } = string.Empty;
+
+    [CommandOption("-o|--output-path <PATH>")]
+    [Description("Output destination path. Supports tokens like '{date}' and '{datetime}'.")]
+    [SupportsTokens]
+    [DefaultValue("./processed-{date}/output.dat")]
+    public string OutputPath { get; set; } = "./processed-{date}/output.dat";
+
+    [CommandOption("-b|--backup")]
+    [Description("Create a backup before processing.")]
+    [DefaultValue(true)]
+    public bool Backup { get; set; }
+}
+
+/// <summary>
+///     Settings for file report command.
+/// </summary>
+public class FileReportCommandSettings : CommandSettings
+{
+    [CommandArgument(0, "<PATH>")]
+    [Description("Path to inspect and generate report for.")]
+    public string Path { get; set; } = string.Empty;
+
+    [CommandOption("-t|--title <TITLE>")]
+    [Description("Report title. Supports tokens like '{date}'.")]
+    [SupportsTokens]
+    [DefaultValue("File Report - {date}")]
+    public string Title { get; set; } = "File Report - {date}";
+}

--- a/samples/SampleApp/src/SampleApp/Commands/Files/FileReportCommand.cs
+++ b/samples/SampleApp/src/SampleApp/Commands/Files/FileReportCommand.cs
@@ -1,0 +1,31 @@
+using Ploch.CommandLine.Spectre.Commands;
+using Ploch.CommandLine.Spectre.Output;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Ploch.CommandLine.Spectre.SampleApp.Commands.Files;
+
+/// <summary>
+///     Command demonstrating report generation for files.
+/// </summary>
+public class FileReportCommand(CommandArgumentsRootProcessor settingsProcessor,
+                               ICommandSettingsValidator<FileReportCommandSettings> validator,
+                               IExceptionHandler exceptionHandler,
+                               IOutput output) : AsyncAppCommand<FileReportCommandSettings>(settingsProcessor, validator, exceptionHandler, output)
+{
+    protected override Task<ExitCode> DoExecuteAsync(CommandContext context, FileReportCommandSettings settings, CancellationToken cancellationToken)
+    {
+        var panel = new Panel(new Markup($"[bold]Report Title:[/] {settings.Title}\n" +
+                                         $"[bold]Source File:[/] {settings.Path}\n" +
+                                         $"[bold]Status:[/] [green]Analyzed[/]\n" +
+                                         $"[bold]Generated:[/] {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss} UTC"))
+        {
+            Header = new PanelHeader($"[bold cyan]{settings.Title}[/]"),
+            Border = BoxBorder.Rounded
+        };
+
+        AnsiConsole.Write(panel);
+
+        return Task.FromResult(ExitCode.Success);
+    }
+}

--- a/samples/SampleApp/src/SampleApp/Commands/Files/FileReportCommand.cs
+++ b/samples/SampleApp/src/SampleApp/Commands/Files/FileReportCommand.cs
@@ -6,25 +6,43 @@ using Spectre.Console.Cli;
 namespace Ploch.CommandLine.Spectre.SampleApp.Commands.Files;
 
 /// <summary>
-///     Command demonstrating report generation for files.
+///     Command demonstrating report generation for a file, input validation and markup escaping.
 /// </summary>
 public class FileReportCommand(CommandArgumentsRootProcessor settingsProcessor,
                                ICommandSettingsValidator<FileReportCommandSettings> validator,
                                IExceptionHandler exceptionHandler,
                                IOutput output) : AsyncAppCommand<FileReportCommandSettings>(settingsProcessor, validator, exceptionHandler, output)
 {
+    /// <inheritdoc />
     protected override Task<ExitCode> DoExecuteAsync(CommandContext context, FileReportCommandSettings settings, CancellationToken cancellationToken)
     {
-        var panel = new Panel(new Markup($"[bold]Report Title:[/] {settings.Title}\n" +
-                                         $"[bold]Source File:[/] {settings.Path}\n" +
-                                         $"[bold]Status:[/] [green]Analyzed[/]\n" +
+        // A path that parses is not a path that exists: report the real state of the input rather
+        // than declaring success for a file that was never opened.
+        var file = new FileInfo(settings.Path);
+        if (!file.Exists)
+        {
+            Output.MarkupLineInterpolated($"[red]File '{settings.Path}' was not found.[/]");
+
+            return Task.FromResult(ExitCode.InvalidInput);
+        }
+
+        // Title and path come from the command line: escape them before they are parsed as markup,
+        // otherwise a '[' in either one breaks the render or injects formatting.
+        var title = Markup.Escape(settings.Title);
+        var path = Markup.Escape(file.FullName);
+
+        var panel = new Panel(new Markup($"[bold]Report Title:[/] {title}\n" +
+                                         $"[bold]Source File:[/] {path}\n" +
+                                         $"[bold]Size:[/] {file.Length} bytes\n" +
+                                         $"[bold]Last Modified:[/] {file.LastWriteTimeUtc:yyyy-MM-dd HH:mm:ss} UTC\n" +
+                                         $"[bold]Status:[/] [green]Analysed[/]\n" +
                                          $"[bold]Generated:[/] {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss} UTC"))
         {
-            Header = new PanelHeader($"[bold cyan]{settings.Title}[/]"),
+            Header = new PanelHeader($"[bold cyan]{title}[/]"),
             Border = BoxBorder.Rounded
         };
 
-        AnsiConsole.Write(panel);
+        Output.Write(panel);
 
         return Task.FromResult(ExitCode.Success);
     }

--- a/samples/SampleApp/src/SampleApp/Commands/Projects/ProjectCreateCommand.cs
+++ b/samples/SampleApp/src/SampleApp/Commands/Projects/ProjectCreateCommand.cs
@@ -1,0 +1,27 @@
+using Ploch.CommandLine.Spectre.Commands;
+using Ploch.CommandLine.Spectre.Output;
+using Ploch.CommandLine.Spectre.SampleApp.Commands.Projects.UseCases;
+using Ploch.CommandLine.UseCases;
+
+namespace Ploch.CommandLine.Spectre.SampleApp.Commands.Projects;
+
+/// <summary>
+///     Command demonstrating <see cref="UseCaseAsyncCommand{TCommandSettings, TUseCase, TUseCaseRequest, TUseCaseResponse}" />.
+///     Integrates cleanly with Clean Architecture use cases and Ardalis.Result.
+/// </summary>
+public class ProjectCreateCommand(IOutput output,
+                                  CreateProjectUseCase useCase,
+                                  CommandArgumentsRootProcessor settingsProcessor,
+                                  ICommandSettingsValidator<ProjectCreateCommandSettings> validator,
+                                  IExceptionHandler exceptionHandler)
+    : UseCaseAsyncCommand<ProjectCreateCommandSettings, CreateProjectUseCase, CreateProjectRequest, CreateProjectResponse>(output,
+                                                                                                                           useCase,
+                                                                                                                           settingsProcessor,
+                                                                                                                           validator,
+                                                                                                                           exceptionHandler)
+{
+    protected override CreateProjectRequest CreateRequest(ProjectCreateCommandSettings commandSettings)
+    {
+        return new CreateProjectRequest(commandSettings.Name, commandSettings.Description, commandSettings.Template);
+    }
+}

--- a/samples/SampleApp/src/SampleApp/Commands/Projects/ProjectExportCommand.cs
+++ b/samples/SampleApp/src/SampleApp/Commands/Projects/ProjectExportCommand.cs
@@ -1,0 +1,26 @@
+using Ploch.CommandLine.Spectre.Commands;
+using Ploch.CommandLine.Spectre.Output;
+using Ploch.CommandLine.Spectre.SampleApp.Commands.Projects.UseCases;
+using Ploch.CommandLine.UseCases;
+
+namespace Ploch.CommandLine.Spectre.SampleApp.Commands.Projects;
+
+/// <summary>
+///     Command demonstrating project export use case.
+/// </summary>
+public class ProjectExportCommand(IOutput output,
+                                  ExportProjectUseCase useCase,
+                                  CommandArgumentsRootProcessor settingsProcessor,
+                                  ICommandSettingsValidator<ProjectExportCommandSettings> validator,
+                                  IExceptionHandler exceptionHandler)
+    : UseCaseAsyncCommand<ProjectExportCommandSettings, ExportProjectUseCase, ExportProjectRequest, ExportProjectResponse>(output,
+                                                                                                                           useCase,
+                                                                                                                           settingsProcessor,
+                                                                                                                           validator,
+                                                                                                                           exceptionHandler)
+{
+    protected override ExportProjectRequest CreateRequest(ProjectExportCommandSettings commandSettings)
+    {
+        return new ExportProjectRequest(commandSettings.Name, commandSettings.OutputPath);
+    }
+}

--- a/samples/SampleApp/src/SampleApp/Commands/Projects/ProjectSettings.cs
+++ b/samples/SampleApp/src/SampleApp/Commands/Projects/ProjectSettings.cs
@@ -1,0 +1,41 @@
+using System.ComponentModel;
+using Ploch.CommandLine.Spectre.Commands;
+using Spectre.Console.Cli;
+
+namespace Ploch.CommandLine.Spectre.SampleApp.Commands.Projects;
+
+/// <summary>
+///     Settings for creating a project.
+/// </summary>
+public class ProjectCreateCommandSettings : CommandSettings
+{
+    [CommandArgument(0, "<NAME>")]
+    [Description("The unique name of the project.")]
+    public string Name { get; set; } = string.Empty;
+
+    [CommandOption("-d|--description <DESC>")]
+    [Description("The description of the project.")]
+    [DefaultValue("Sample project")]
+    public string Description { get; set; } = "Sample project";
+
+    [CommandOption("-t|--template <TEMPLATE>")]
+    [Description("The project template (e.g. Console, WebAPI, Library).")]
+    [DefaultValue("Console")]
+    public string Template { get; set; } = "Console";
+}
+
+/// <summary>
+///     Settings for exporting a project.
+/// </summary>
+public class ProjectExportCommandSettings : CommandSettings
+{
+    [CommandArgument(0, "<NAME>")]
+    [Description("The name of the project to export.")]
+    public string Name { get; set; } = string.Empty;
+
+    [CommandOption("-o|--output <PATH>")]
+    [Description("Destination output directory. Supports '{date}' token.")]
+    [SupportsTokens]
+    [DefaultValue("./exports-{date}")]
+    public string OutputPath { get; set; } = "./exports-{date}";
+}

--- a/samples/SampleApp/src/SampleApp/Commands/Projects/UseCases/CreateProjectRequest.cs
+++ b/samples/SampleApp/src/SampleApp/Commands/Projects/UseCases/CreateProjectRequest.cs
@@ -1,0 +1,11 @@
+namespace Ploch.CommandLine.Spectre.SampleApp.Commands.Projects.UseCases;
+
+/// <summary>
+///     Request DTO for creating a project use case.
+/// </summary>
+public record CreateProjectRequest(string Name, string Description, string Template);
+
+/// <summary>
+///     Response DTO for creating a project use case.
+/// </summary>
+public record CreateProjectResponse(string Name, string Description, string Template, DateTime CreatedAt);

--- a/samples/SampleApp/src/SampleApp/Commands/Projects/UseCases/CreateProjectUseCase.cs
+++ b/samples/SampleApp/src/SampleApp/Commands/Projects/UseCases/CreateProjectUseCase.cs
@@ -1,0 +1,33 @@
+using Ardalis.Result;
+using Ploch.CommandLine.Spectre.SampleApp.Services;
+using Ploch.CommandLine.Spectre.SampleApp.Services.Models;
+using Ploch.CommandLine.UseCases;
+
+namespace Ploch.CommandLine.Spectre.SampleApp.Commands.Projects.UseCases;
+
+/// <summary>
+///     Use case for creating a project, demonstrating <see cref="IResultUseCase{TRequest, TResponse}" /> with Ardalis.Result.
+/// </summary>
+public class CreateProjectUseCase(IProjectRepository projectRepository) : IResultUseCase<CreateProjectRequest, CreateProjectResponse>
+{
+    public async Task<Result<CreateProjectResponse>> ExecuteAsync(CreateProjectRequest request, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(request.Name))
+        {
+            return Result<CreateProjectResponse>.Error("Project name cannot be empty.");
+        }
+
+        var existing = await projectRepository.GetByNameAsync(request.Name, cancellationToken);
+        if (existing != null)
+        {
+            return Result<CreateProjectResponse>.Conflict($"A project with name '{request.Name}' already exists.");
+        }
+
+        var project = new ProjectItem(request.Name, request.Description, request.Template, DateTime.UtcNow);
+        await projectRepository.AddAsync(project, cancellationToken);
+
+        var response = new CreateProjectResponse(project.Name, project.Description, project.Template, project.CreatedAt);
+
+        return Result<CreateProjectResponse>.Success(response);
+    }
+}

--- a/samples/SampleApp/src/SampleApp/Commands/Projects/UseCases/ExportProjectRequest.cs
+++ b/samples/SampleApp/src/SampleApp/Commands/Projects/UseCases/ExportProjectRequest.cs
@@ -1,0 +1,11 @@
+namespace Ploch.CommandLine.Spectre.SampleApp.Commands.Projects.UseCases;
+
+/// <summary>
+///     Request DTO for exporting a project use case.
+/// </summary>
+public record ExportProjectRequest(string Name, string OutputPath);
+
+/// <summary>
+///     Response DTO for exporting a project use case.
+/// </summary>
+public record ExportProjectResponse(string Name, string OutputPath, int ItemCount, DateTime ExportedAt);

--- a/samples/SampleApp/src/SampleApp/Commands/Projects/UseCases/ExportProjectUseCase.cs
+++ b/samples/SampleApp/src/SampleApp/Commands/Projects/UseCases/ExportProjectUseCase.cs
@@ -1,0 +1,24 @@
+using Ardalis.Result;
+using Ploch.CommandLine.Spectre.SampleApp.Services;
+using Ploch.CommandLine.UseCases;
+
+namespace Ploch.CommandLine.Spectre.SampleApp.Commands.Projects.UseCases;
+
+/// <summary>
+///     Use case for exporting a project.
+/// </summary>
+public class ExportProjectUseCase(IProjectRepository projectRepository) : IResultUseCase<ExportProjectRequest, ExportProjectResponse>
+{
+    public async Task<Result<ExportProjectResponse>> ExecuteAsync(ExportProjectRequest request, CancellationToken cancellationToken = default)
+    {
+        var project = await projectRepository.GetByNameAsync(request.Name, cancellationToken);
+        if (project == null)
+        {
+            return Result<ExportProjectResponse>.NotFound($"Project '{request.Name}' was not found.");
+        }
+
+        var response = new ExportProjectResponse(project.Name, request.OutputPath, 1, DateTime.UtcNow);
+
+        return Result<ExportProjectResponse>.Success(response);
+    }
+}

--- a/samples/SampleApp/src/SampleApp/Commands/Projects/UseCases/ExportProjectUseCase.cs
+++ b/samples/SampleApp/src/SampleApp/Commands/Projects/UseCases/ExportProjectUseCase.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Ardalis.Result;
 using Ploch.CommandLine.Spectre.SampleApp.Services;
 using Ploch.CommandLine.UseCases;
@@ -5,10 +6,13 @@ using Ploch.CommandLine.UseCases;
 namespace Ploch.CommandLine.Spectre.SampleApp.Commands.Projects.UseCases;
 
 /// <summary>
-///     Use case for exporting a project.
+///     Use case for exporting a project: writes a manifest for the project into the requested directory.
 /// </summary>
 public class ExportProjectUseCase(IProjectRepository projectRepository) : IResultUseCase<ExportProjectRequest, ExportProjectResponse>
 {
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    /// <inheritdoc />
     public async Task<Result<ExportProjectResponse>> ExecuteAsync(ExportProjectRequest request, CancellationToken cancellationToken = default)
     {
         var project = await projectRepository.GetByNameAsync(request.Name, cancellationToken);
@@ -17,8 +21,22 @@ public class ExportProjectUseCase(IProjectRepository projectRepository) : IResul
             return Result<ExportProjectResponse>.NotFound($"Project '{request.Name}' was not found.");
         }
 
-        var response = new ExportProjectResponse(project.Name, request.OutputPath, 1, DateTime.UtcNow);
+        // A use case that reports a successful export has to have exported something: the file is
+        // written here, and an I/O failure becomes a failed Result rather than a silent success.
+        string manifestPath;
+        try
+        {
+            Directory.CreateDirectory(request.OutputPath);
+            manifestPath = Path.Combine(request.OutputPath, $"{project.Name}.json");
 
-        return Result<ExportProjectResponse>.Success(response);
+            var manifest = JsonSerializer.Serialize(project, JsonOptions);
+            await File.WriteAllTextAsync(manifestPath, manifest, cancellationToken);
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or NotSupportedException or ArgumentException)
+        {
+            return Result<ExportProjectResponse>.Error($"Could not write the export to '{request.OutputPath}': {exception.Message}");
+        }
+
+        return Result<ExportProjectResponse>.Success(new(project.Name, manifestPath, 1, DateTime.UtcNow));
     }
 }

--- a/samples/SampleApp/src/SampleApp/Commands/Users/UserAddCommand.cs
+++ b/samples/SampleApp/src/SampleApp/Commands/Users/UserAddCommand.cs
@@ -15,6 +15,7 @@ public class UserAddCommand(CommandArgumentsRootProcessor settingsProcessor,
                             IOutput output,
                             IUserService userService) : AsyncAppCommand<UserAddCommandSettings>(settingsProcessor, validator, exceptionHandler, output)
 {
+    /// <inheritdoc />
     protected override async Task<ExitCode> DoExecuteAsync(CommandContext context, UserAddCommandSettings settings, CancellationToken cancellationToken)
     {
         if (settings.Verbose)
@@ -26,10 +27,14 @@ public class UserAddCommand(CommandArgumentsRootProcessor settingsProcessor,
 
         var user = await userService.CreateUserAsync(settings.Name, settings.Email, settings.Role, cancellationToken);
 
+        // Everything the user typed is escaped before it reaches Markup: a name such as "A[dmin]"
+        // would otherwise be parsed as markup and throw after the account had already been created.
+        // MarkupLineInterpolated does this for its holes automatically; a Markup built from a string
+        // does not.
         var panel = new Panel(new Markup($"[bold]User ID:[/] {user.Id}\n" +
-                                         $"[bold]Name:[/] {user.Name}\n" +
-                                         $"[bold]Email:[/] {user.Email}\n" +
-                                         $"[bold]Role:[/] [green]{user.Role}[/]\n" +
+                                         $"[bold]Name:[/] {Markup.Escape(user.Name)}\n" +
+                                         $"[bold]Email:[/] {Markup.Escape(user.Email)}\n" +
+                                         $"[bold]Role:[/] [green]{Markup.Escape(user.Role)}[/]\n" +
                                          $"[bold]Active:[/] {(user.IsActive ? "[green]Yes[/]" : "[red]No[/]")}\n" +
                                          $"[bold]Created:[/] {user.CreatedAt:yyyy-MM-dd HH:mm:ss} UTC"))
         {
@@ -37,7 +42,7 @@ public class UserAddCommand(CommandArgumentsRootProcessor settingsProcessor,
             Border = BoxBorder.Rounded
         };
 
-        AnsiConsole.Write(panel);
+        Output.Write(panel);
 
         return ExitCode.Success;
     }

--- a/samples/SampleApp/src/SampleApp/Commands/Users/UserAddCommand.cs
+++ b/samples/SampleApp/src/SampleApp/Commands/Users/UserAddCommand.cs
@@ -1,0 +1,44 @@
+using Ploch.CommandLine.Spectre.Commands;
+using Ploch.CommandLine.Spectre.Output;
+using Ploch.CommandLine.Spectre.SampleApp.Services;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Ploch.CommandLine.Spectre.SampleApp.Commands.Users;
+
+/// <summary>
+///     Asynchronous command demonstrating <see cref="AsyncAppCommand{TSettings}" /> with dependency injection.
+/// </summary>
+public class UserAddCommand(CommandArgumentsRootProcessor settingsProcessor,
+                            ICommandSettingsValidator<UserAddCommandSettings> validator,
+                            IExceptionHandler exceptionHandler,
+                            IOutput output,
+                            IUserService userService) : AsyncAppCommand<UserAddCommandSettings>(settingsProcessor, validator, exceptionHandler, output)
+{
+    protected override async Task<ExitCode> DoExecuteAsync(CommandContext context, UserAddCommandSettings settings, CancellationToken cancellationToken)
+    {
+        if (settings.Verbose)
+        {
+            Output.MarkupLineInterpolated($"[dim]Verbose: email='{settings.Email}', role='{settings.Role}'.[/]");
+        }
+
+        Output.MarkupLineInterpolated($"[cyan]Creating new user account for[/] [bold yellow]{settings.Name}[/]...");
+
+        var user = await userService.CreateUserAsync(settings.Name, settings.Email, settings.Role, cancellationToken);
+
+        var panel = new Panel(new Markup($"[bold]User ID:[/] {user.Id}\n" +
+                                         $"[bold]Name:[/] {user.Name}\n" +
+                                         $"[bold]Email:[/] {user.Email}\n" +
+                                         $"[bold]Role:[/] [green]{user.Role}[/]\n" +
+                                         $"[bold]Active:[/] {(user.IsActive ? "[green]Yes[/]" : "[red]No[/]")}\n" +
+                                         $"[bold]Created:[/] {user.CreatedAt:yyyy-MM-dd HH:mm:ss} UTC"))
+        {
+            Header = new PanelHeader("[bold green]User Created Successfully[/]"),
+            Border = BoxBorder.Rounded
+        };
+
+        AnsiConsole.Write(panel);
+
+        return ExitCode.Success;
+    }
+}

--- a/samples/SampleApp/src/SampleApp/Commands/Users/UserDeleteCommand.cs
+++ b/samples/SampleApp/src/SampleApp/Commands/Users/UserDeleteCommand.cs
@@ -1,0 +1,48 @@
+using Microsoft.Extensions.Logging;
+using Ploch.CommandLine.Spectre.Commands;
+using Ploch.CommandLine.Spectre.Output;
+using Ploch.CommandLine.Spectre.SampleApp.Services;
+using Spectre.Console.Cli;
+
+namespace Ploch.CommandLine.Spectre.SampleApp.Commands.Users;
+
+/// <summary>
+///     Command to delete a user by ID. Demonstrates injecting an <see cref="ILogger{TCategoryName}" /> alongside
+///     <see cref="IOutput" />: the console output is what the user reads, the log is what an operator inspects later.
+/// </summary>
+public class UserDeleteCommand(CommandArgumentsRootProcessor settingsProcessor,
+                               ICommandSettingsValidator<UserDeleteCommandSettings> validator,
+                               IExceptionHandler exceptionHandler,
+                               IOutput output,
+                               IUserService userService,
+                               ILogger<UserDeleteCommand> logger) : AsyncAppCommand<UserDeleteCommandSettings>(settingsProcessor,
+                                                                                                               validator,
+                                                                                                               exceptionHandler,
+                                                                                                               output)
+{
+    /// <inheritdoc />
+    protected override async Task<ExitCode> DoExecuteAsync(CommandContext context, UserDeleteCommandSettings settings, CancellationToken cancellationToken)
+    {
+        if (settings.Verbose)
+        {
+            Output.MarkupLineInterpolated($"[dim]Verbose: deleting without confirmation prompt is {(settings.Force ? "enabled" : "disabled")}.[/]");
+        }
+
+        Output.MarkupLineInterpolated($"[dim]Deleting user with ID: {settings.Id} (force: {settings.Force})...[/]");
+
+        var deleted = await userService.DeleteUserAsync(settings.Id, cancellationToken);
+
+        if (!deleted)
+        {
+            logger.LogWarning("[UserDeleteCommand] Delete requested for unknown user {UserId}", settings.Id);
+            Output.MarkupLineInterpolated($"[red]User with ID {settings.Id} was not found.[/]");
+
+            return ExitCode.Error;
+        }
+
+        logger.LogInformation("[UserDeleteCommand] Deleted user {UserId}", settings.Id);
+        Output.MarkupLineInterpolated($"[green]User {settings.Id} deleted successfully.[/]");
+
+        return ExitCode.Success;
+    }
+}

--- a/samples/SampleApp/src/SampleApp/Commands/Users/UserDeleteCommand.cs
+++ b/samples/SampleApp/src/SampleApp/Commands/Users/UserDeleteCommand.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using Ploch.CommandLine.Spectre.Commands;
 using Ploch.CommandLine.Spectre.Output;
 using Ploch.CommandLine.Spectre.SampleApp.Services;
+using Spectre.Console;
 using Spectre.Console.Cli;
 
 namespace Ploch.CommandLine.Spectre.SampleApp.Commands.Users;
@@ -9,6 +10,8 @@ namespace Ploch.CommandLine.Spectre.SampleApp.Commands.Users;
 /// <summary>
 ///     Command to delete a user by ID. Demonstrates injecting an <see cref="ILogger{TCategoryName}" /> alongside
 ///     <see cref="IOutput" />: the console output is what the user reads, the log is what an operator inspects later.
+///     It also shows the usual contract for a destructive command — confirm interactively, or require an explicit
+///     <c>--force</c> when there is nobody to ask.
 /// </summary>
 public class UserDeleteCommand(CommandArgumentsRootProcessor settingsProcessor,
                                ICommandSettingsValidator<UserDeleteCommandSettings> validator,
@@ -25,7 +28,16 @@ public class UserDeleteCommand(CommandArgumentsRootProcessor settingsProcessor,
     {
         if (settings.Verbose)
         {
-            Output.MarkupLineInterpolated($"[dim]Verbose: deleting without confirmation prompt is {(settings.Force ? "enabled" : "disabled")}.[/]");
+            Output.MarkupLineInterpolated($"[dim]Verbose: confirmation prompt is {(settings.Force ? "suppressed" : "enabled")}.[/]");
+        }
+
+        if (!settings.Force)
+        {
+            var refusal = ConfirmDeletion(settings.Id);
+            if (refusal is not null)
+            {
+                return refusal.Value;
+            }
         }
 
         Output.MarkupLineInterpolated($"[dim]Deleting user with ID: {settings.Id} (force: {settings.Force})...[/]");
@@ -44,5 +56,28 @@ public class UserDeleteCommand(CommandArgumentsRootProcessor settingsProcessor,
         Output.MarkupLineInterpolated($"[green]User {settings.Id} deleted successfully.[/]");
 
         return ExitCode.Success;
+    }
+
+    /// <summary>
+    ///     Asks the operator to confirm the deletion, or explains how to skip the prompt when the console
+    ///     cannot answer (a pipeline, a redirected stream).
+    /// </summary>
+    /// <param name="userId">The identifier of the user about to be deleted.</param>
+    /// <returns>
+    ///     <see langword="null" /> when the deletion may proceed; otherwise the exit code to return.
+    ///     A missing <c>--force</c> on a non-interactive console is an input problem
+    ///     (<see cref="ExitCode.InvalidInput" />); answering "no" at the prompt is a deliberate
+    ///     cancellation (<see cref="ExitCode.Cancelled" />).
+    /// </returns>
+    private ExitCode? ConfirmDeletion(int userId)
+    {
+        if (!AnsiConsole.Profile.Capabilities.Interactive)
+        {
+            Output.MarkupLineInterpolated($"[yellow]Refusing to delete user {userId} without confirmation. Re-run with --force.[/]");
+
+            return ExitCode.InvalidInput;
+        }
+
+        return AnsiConsole.Confirm($"Delete user {userId}?", defaultValue: false) ? null : ExitCode.Cancelled;
     }
 }

--- a/samples/SampleApp/src/SampleApp/Commands/Users/UserListCommand.cs
+++ b/samples/SampleApp/src/SampleApp/Commands/Users/UserListCommand.cs
@@ -65,10 +65,18 @@ public class UserListCommand(CommandArgumentsRootProcessor settingsProcessor,
             foreach (var user in users)
             {
                 var status = user.IsActive ? "[green]Active[/]" : "[red]Inactive[/]";
-                table.AddRow(user.Id.ToString(), user.Name, user.Email, user.Role, status, user.CreatedAt.ToString("yyyy-MM-dd"));
+
+                // Table cells are markup: escape the stored values so a name or email containing
+                // '[' renders as text instead of throwing.
+                table.AddRow(user.Id.ToString(),
+                             Markup.Escape(user.Name),
+                             Markup.Escape(user.Email),
+                             Markup.Escape(user.Role),
+                             status,
+                             user.CreatedAt.ToString("yyyy-MM-dd"));
             }
 
-            AnsiConsole.Write(table);
+            Output.Write(table);
         }
 
         Output.WriteLine();

--- a/samples/SampleApp/src/SampleApp/Commands/Users/UserListCommand.cs
+++ b/samples/SampleApp/src/SampleApp/Commands/Users/UserListCommand.cs
@@ -1,0 +1,79 @@
+using Ploch.CommandLine.Spectre.Commands;
+using Ploch.CommandLine.Spectre.Output;
+using Ploch.CommandLine.Spectre.SampleApp.Services;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Ploch.CommandLine.Spectre.SampleApp.Commands.Users;
+
+/// <summary>
+///     Command to list users in the system formatted as a Spectre Table.
+/// </summary>
+public class UserListCommand(CommandArgumentsRootProcessor settingsProcessor,
+                             ICommandSettingsValidator<UserListCommandSettings> validator,
+                             IExceptionHandler exceptionHandler,
+                             IOutput output,
+                             IUserService userService) : AsyncAppCommand<UserListCommandSettings>(settingsProcessor, validator, exceptionHandler, output)
+{
+    private static readonly string[] SupportedFormats = ["table", "compact"];
+
+    /// <inheritdoc />
+    protected override async Task<ExitCode> DoExecuteAsync(CommandContext context, UserListCommandSettings settings, CancellationToken cancellationToken)
+    {
+        // Settings that Spectre cannot express as a type (here: an enumeration of two literal
+        // formats) are checked by the command itself and reported with ExitCode.InvalidInput.
+        if (!SupportedFormats.Contains(settings.Format, StringComparer.OrdinalIgnoreCase))
+        {
+            Output.MarkupLineInterpolated($"[red]Unsupported format '{settings.Format}'. Supported formats: {string.Join(", ", SupportedFormats)}.[/]");
+
+            return ExitCode.InvalidInput;
+        }
+
+        if (settings.Verbose)
+        {
+            Output.MarkupLineInterpolated($"[dim]Verbose: format='{settings.Format}', active only='{settings.ActiveOnly}'.[/]");
+        }
+
+        Output.MarkupLineInterpolated($"[dim]Retrieving users (active only: {settings.ActiveOnly})...[/]");
+
+        var users = (await userService.GetUsersAsync(settings.ActiveOnly, cancellationToken)).ToList();
+
+        if (users.Count == 0)
+        {
+            Output.MarkupLineInterpolated($"[yellow]No users found matching the criteria.[/]");
+
+            return ExitCode.Success;
+        }
+
+        if (string.Equals(settings.Format, "compact", StringComparison.OrdinalIgnoreCase))
+        {
+            foreach (var user in users)
+            {
+                Output.MarkupLineInterpolated($"[[{user.Id}]] [bold]{user.Name}[/] <{user.Email}> ({user.Role}) - Active: {user.IsActive}");
+            }
+        }
+        else
+        {
+            var table = new Table().Border(TableBorder.Rounded).Title("[bold cyan]Registered Users[/]");
+            table.AddColumn("[yellow]ID[/]");
+            table.AddColumn("[yellow]Name[/]");
+            table.AddColumn("[yellow]Email[/]");
+            table.AddColumn("[yellow]Role[/]");
+            table.AddColumn("[yellow]Status[/]");
+            table.AddColumn("[yellow]Created At[/]");
+
+            foreach (var user in users)
+            {
+                var status = user.IsActive ? "[green]Active[/]" : "[red]Inactive[/]";
+                table.AddRow(user.Id.ToString(), user.Name, user.Email, user.Role, status, user.CreatedAt.ToString("yyyy-MM-dd"));
+            }
+
+            AnsiConsole.Write(table);
+        }
+
+        Output.WriteLine();
+        Output.MarkupLineInterpolated($"[green]Total users: {users.Count}[/]");
+
+        return ExitCode.Success;
+    }
+}

--- a/samples/SampleApp/src/SampleApp/Commands/Users/UserSettings.cs
+++ b/samples/SampleApp/src/SampleApp/Commands/Users/UserSettings.cs
@@ -1,0 +1,55 @@
+using System.ComponentModel;
+using Ploch.CommandLine.Spectre.SampleApp.Commands.Common;
+using Spectre.Console.Cli;
+
+namespace Ploch.CommandLine.Spectre.SampleApp.Commands.Users;
+
+/// <summary>
+///     Settings for the user add command.
+/// </summary>
+public class UserAddCommandSettings : GlobalSettings
+{
+    [CommandArgument(0, "<NAME>")]
+    [Description("The full name of the user.")]
+    public string Name { get; set; } = string.Empty;
+
+    [CommandOption("-e|--email <EMAIL>")]
+    [Description("The email address of the user.")]
+    public string Email { get; set; } = string.Empty;
+
+    [CommandOption("-r|--role <ROLE>")]
+    [Description("The role of the user (e.g. Administrator, Developer, Viewer).")]
+    [DefaultValue("Developer")]
+    public string Role { get; set; } = "Developer";
+}
+
+/// <summary>
+///     Settings for the user list command.
+/// </summary>
+public class UserListCommandSettings : GlobalSettings
+{
+    [CommandOption("-a|--active-only")]
+    [Description("Only display active user accounts.")]
+    [DefaultValue(false)]
+    public bool ActiveOnly { get; set; }
+
+    [CommandOption("-f|--format <FORMAT>")]
+    [Description("The output format: 'table' or 'compact'.")]
+    [DefaultValue("table")]
+    public string Format { get; set; } = "table";
+}
+
+/// <summary>
+///     Settings for the user delete command.
+/// </summary>
+public class UserDeleteCommandSettings : GlobalSettings
+{
+    [CommandArgument(0, "<ID>")]
+    [Description("The numeric ID of the user to delete.")]
+    public int Id { get; set; }
+
+    [CommandOption("--force")]
+    [Description("Force deletion without confirmation.")]
+    [DefaultValue(false)]
+    public bool Force { get; set; }
+}

--- a/samples/SampleApp/src/SampleApp/Commands/Users/Validators/UserAddCommandSettingsValidator.cs
+++ b/samples/SampleApp/src/SampleApp/Commands/Users/Validators/UserAddCommandSettingsValidator.cs
@@ -1,0 +1,26 @@
+using FluentValidation;
+
+namespace Ploch.CommandLine.Spectre.SampleApp.Commands.Users.Validators;
+
+/// <summary>
+///     FluentValidation validator for <see cref="UserAddCommandSettings" />.
+///     Demonstrates automatic validation integration with Ploch.CommandLine.Spectre.FluentValidation.
+/// </summary>
+public class UserAddCommandSettingsValidator : AbstractValidator<UserAddCommandSettings>
+{
+    public UserAddCommandSettingsValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty().WithMessage("User name is required.")
+            .MinimumLength(2).WithMessage("User name must be at least 2 characters long.");
+
+        RuleFor(x => x.Email)
+            .NotEmpty().WithMessage("User email is required.")
+            .EmailAddress().WithMessage("A valid email address must be provided.");
+
+        RuleFor(x => x.Role)
+            .NotEmpty().WithMessage("Role cannot be empty.")
+            .Must(role => role is "Administrator" or "Developer" or "Viewer" or "Contributor")
+            .WithMessage("Role must be one of: Administrator, Developer, Viewer, Contributor.");
+    }
+}

--- a/samples/SampleApp/src/SampleApp/Ploch.CommandLine.Spectre.SampleApp.csproj
+++ b/samples/SampleApp/src/SampleApp/Ploch.CommandLine.Spectre.SampleApp.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(TargetFrameworkVersion)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Ploch.CommandLine.Spectre.SampleApp</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Ploch.CommandLine.Spectre" />
+    <PackageReference Include="Ploch.CommandLine.Spectre.FluentValidation" />
+    <PackageReference Include="Ploch.CommandLine.Spectre.Serilog" />
+    <PackageReference Include="Ploch.CommandLine.UseCases" />
+    <PackageReference Include="Ploch.Common" />
+    <PackageReference Include="Ploch.Common.DependencyInjection" />
+    <PackageReference Include="Spectre.Console" />
+    <PackageReference Include="Spectre.Console.Cli" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
+    <PackageReference Include="Ardalis.Result" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/samples/SampleApp/src/SampleApp/Program.cs
+++ b/samples/SampleApp/src/SampleApp/Program.cs
@@ -1,0 +1,127 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Ploch.CommandLine.Spectre;
+using Ploch.CommandLine.Spectre.FluentValidation;
+using Ploch.CommandLine.Spectre.SampleApp.Commands.Common;
+using Ploch.CommandLine.Spectre.SampleApp.Commands.Config;
+using Ploch.CommandLine.Spectre.SampleApp.Commands.Files;
+using Ploch.CommandLine.Spectre.SampleApp.Commands.Projects;
+using Ploch.CommandLine.Spectre.SampleApp.Commands.Projects.UseCases;
+using Ploch.CommandLine.Spectre.SampleApp.Commands.Users;
+using Ploch.CommandLine.Spectre.SampleApp.Services;
+using Ploch.CommandLine.Spectre.Serilog;
+using Spectre.Console.Cli;
+
+// 1. Create and configure the AppBuilder
+var appBuilder = AppBuilder.Create(args)
+                           .WithName("Ploch.CommandLine.Spectre Sample CLI")
+                           .WithVersion(new Version(1, 0, 0))
+                           .WithDescription("Showcase application demonstrating Ploch.CommandLine.Spectre features, " +
+                                            "multi-level sub-commands, FluentValidation, tokens, and Clean Architecture use cases.")
+
+                           // The host resolves relative configuration file paths against the current working
+                           // directory. A CLI is invoked from wherever the user happens to be, so appsettings.json
+                           // is loaded from the directory the application was deployed to instead.
+                           .ConfigureAppConfiguration(configuration => configuration.SetBasePath(AppContext.BaseDirectory)
+                                                                                    .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true))
+                           .ConfigureServices((context, services) =>
+                           {
+                               // Serilog reads its minimum level from the "Serilog" section of appsettings.json and
+                               // writes to the console plus a rolling log file under the application's log directory.
+                               services.AddSerilog(context.Configuration,
+                                                   logName: "sample",
+                                                   logPath: Path.Combine(AppContext.BaseDirectory, "logs"));
+
+                               // Register domain services & repositories
+                               services.AddSingleton<IUserService, UserService>();
+                               services.AddSingleton<IProjectRepository, InMemoryProjectRepository>();
+
+                               // Register Clean Architecture use cases
+                               services.AddTransient<CreateProjectUseCase>();
+                               services.AddTransient<ExportProjectUseCase>();
+
+                               // Register FluentValidation validators
+                               services.AddCommandLineSettingsFluentValidation(builder =>
+                                   builder.AddAssembly(typeof(Program).Assembly));
+                           });
+
+// 2. Configure the composite command structure with multi-level commands and branches
+var executor = appBuilder.ConfigureCommandApp(config =>
+{
+    config.SetApplicationName("sample");
+
+    // Root-level command
+    config.AddCommand<InfoCommand>("info")
+          .WithDescription("Display system, application, and host runtime information.")
+          .WithExample("info")
+          .WithExample("info", "-d");
+
+    // Branch: 'user' commands
+    config.AddBranch("user", user =>
+    {
+        user.SetDescription("Manage user accounts and profile data.");
+
+        user.AddCommand<UserAddCommand>("add")
+            .WithDescription("Create a new user account with validation.")
+            .WithExample("user", "add", "Alice Smith", "-e", "alice@example.com", "-r", "Administrator");
+
+        user.AddCommand<UserListCommand>("list")
+            .WithDescription("List registered user accounts in a rich table.")
+            .WithExample("user", "list")
+            .WithExample("user", "list", "-a", "-f", "compact");
+
+        user.AddCommand<UserDeleteCommand>("delete")
+            .WithDescription("Delete a user account by ID.")
+            .WithExample("user", "delete", "1", "--force");
+    });
+
+    // Branch: 'config' commands
+    config.AddBranch("config", cfg =>
+    {
+        cfg.SetDescription("Inspect and manage application configuration settings.");
+
+        cfg.AddCommand<ConfigGetCommand>("get")
+           .WithDescription("Retrieve a configuration value by key.")
+           .WithExample("config", "get", "SampleAppSettings:Environment");
+
+        cfg.AddCommand<ConfigSetCommand>("set")
+           .WithDescription("Update a configuration value in memory.")
+           .WithExample("config", "set", "SampleAppSettings:MaxBatchSize", "250");
+
+        cfg.AddCommand<ConfigShowCommand>("show")
+           .WithDescription("Display configuration hierarchy as a formatted tree.")
+           .WithExample("config", "show")
+           .WithExample("config", "show", "-s", "SampleAppSettings");
+    });
+
+    // Branch: 'file' commands (with token replacement)
+    config.AddBranch("file", file =>
+    {
+        file.SetDescription("File processing and report generation utilities.");
+
+        file.AddCommand<FileProcessCommand>("process")
+            .WithDescription("Process a file with automatic '{date}' and '{datetime}' token resolution.")
+            .WithExample("file", "process", "input.csv", "-o", "./output-{date}/data.dat");
+
+        file.AddCommand<FileReportCommand>("report")
+            .WithDescription("Generate analysis report for a file.")
+            .WithExample("file", "report", "input.csv", "-t", "Daily Report - {date}");
+    });
+
+    // Branch: 'project' commands (with Clean Architecture UseCases)
+    config.AddBranch("project", proj =>
+    {
+        proj.SetDescription("Project operations powered by Clean Architecture use cases and Ardalis.Result.");
+
+        proj.AddCommand<ProjectCreateCommand>("create")
+            .WithDescription("Create a new project using the CreateProject use case.")
+            .WithExample("project", "create", "NewApp", "-d", "My new application", "-t", "Console");
+
+        proj.AddCommand<ProjectExportCommand>("export")
+            .WithDescription("Export a project bundle using the ExportProject use case.")
+            .WithExample("project", "export", "SpectreDemo", "-o", "./exports-{date}");
+    });
+});
+
+// 3. Execute the command-line application
+return executor.Run(args);

--- a/samples/SampleApp/src/SampleApp/Services/IProjectRepository.cs
+++ b/samples/SampleApp/src/SampleApp/Services/IProjectRepository.cs
@@ -1,0 +1,15 @@
+using Ploch.CommandLine.Spectre.SampleApp.Services.Models;
+
+namespace Ploch.CommandLine.Spectre.SampleApp.Services;
+
+/// <summary>
+///     Repository interface for sample projects.
+/// </summary>
+public interface IProjectRepository
+{
+    Task<ProjectItem?> GetByNameAsync(string name, CancellationToken cancellationToken = default);
+
+    Task AddAsync(ProjectItem project, CancellationToken cancellationToken = default);
+
+    Task<IEnumerable<ProjectItem>> GetAllAsync(CancellationToken cancellationToken = default);
+}

--- a/samples/SampleApp/src/SampleApp/Services/IUserService.cs
+++ b/samples/SampleApp/src/SampleApp/Services/IUserService.cs
@@ -1,0 +1,15 @@
+using Ploch.CommandLine.Spectre.SampleApp.Services.Models;
+
+namespace Ploch.CommandLine.Spectre.SampleApp.Services;
+
+/// <summary>
+///     Service for managing users in the sample application.
+/// </summary>
+public interface IUserService
+{
+    Task<UserProfile> CreateUserAsync(string name, string email, string role, CancellationToken cancellationToken = default);
+
+    Task<IEnumerable<UserProfile>> GetUsersAsync(bool activeOnly = false, CancellationToken cancellationToken = default);
+
+    Task<bool> DeleteUserAsync(int id, CancellationToken cancellationToken = default);
+}

--- a/samples/SampleApp/src/SampleApp/Services/InMemoryProjectRepository.cs
+++ b/samples/SampleApp/src/SampleApp/Services/InMemoryProjectRepository.cs
@@ -18,6 +18,8 @@ public class InMemoryProjectRepository : IProjectRepository
 
     public Task<ProjectItem?> GetByNameAsync(string name, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         _projects.TryGetValue(name, out var project);
 
         return Task.FromResult(project);
@@ -25,6 +27,8 @@ public class InMemoryProjectRepository : IProjectRepository
 
     public Task AddAsync(ProjectItem project, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         _projects[project.Name] = project;
 
         return Task.CompletedTask;
@@ -32,6 +36,8 @@ public class InMemoryProjectRepository : IProjectRepository
 
     public Task<IEnumerable<ProjectItem>> GetAllAsync(CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         return Task.FromResult<IEnumerable<ProjectItem>>(_projects.Values.ToList());
     }
 }

--- a/samples/SampleApp/src/SampleApp/Services/InMemoryProjectRepository.cs
+++ b/samples/SampleApp/src/SampleApp/Services/InMemoryProjectRepository.cs
@@ -1,0 +1,37 @@
+using System.Collections.Concurrent;
+using Ploch.CommandLine.Spectre.SampleApp.Services.Models;
+
+namespace Ploch.CommandLine.Spectre.SampleApp.Services;
+
+/// <summary>
+///     In-memory implementation of <see cref="IProjectRepository" />.
+/// </summary>
+public class InMemoryProjectRepository : IProjectRepository
+{
+    private readonly ConcurrentDictionary<string, ProjectItem> _projects = new(StringComparer.OrdinalIgnoreCase);
+
+    public InMemoryProjectRepository()
+    {
+        _projects["SpectreDemo"] = new ProjectItem("SpectreDemo", "Demo project for Spectre Console CLI", "Console", DateTime.UtcNow.AddDays(-10));
+        _projects["WebBackend"] = new ProjectItem("WebBackend", "API backend project", "WebAPI", DateTime.UtcNow.AddDays(-20));
+    }
+
+    public Task<ProjectItem?> GetByNameAsync(string name, CancellationToken cancellationToken = default)
+    {
+        _projects.TryGetValue(name, out var project);
+
+        return Task.FromResult(project);
+    }
+
+    public Task AddAsync(ProjectItem project, CancellationToken cancellationToken = default)
+    {
+        _projects[project.Name] = project;
+
+        return Task.CompletedTask;
+    }
+
+    public Task<IEnumerable<ProjectItem>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult<IEnumerable<ProjectItem>>(_projects.Values.ToList());
+    }
+}

--- a/samples/SampleApp/src/SampleApp/Services/Models/ProjectItem.cs
+++ b/samples/SampleApp/src/SampleApp/Services/Models/ProjectItem.cs
@@ -1,0 +1,6 @@
+namespace Ploch.CommandLine.Spectre.SampleApp.Services.Models;
+
+/// <summary>
+///     Represents a sample project item.
+/// </summary>
+public record ProjectItem(string Name, string Description, string Template, DateTime CreatedAt);

--- a/samples/SampleApp/src/SampleApp/Services/Models/UserProfile.cs
+++ b/samples/SampleApp/src/SampleApp/Services/Models/UserProfile.cs
@@ -1,0 +1,6 @@
+namespace Ploch.CommandLine.Spectre.SampleApp.Services.Models;
+
+/// <summary>
+///     Represents a sample user profile.
+/// </summary>
+public record UserProfile(int Id, string Name, string Email, string Role, bool IsActive, DateTime CreatedAt);

--- a/samples/SampleApp/src/SampleApp/Services/UserService.cs
+++ b/samples/SampleApp/src/SampleApp/Services/UserService.cs
@@ -1,0 +1,56 @@
+using System.Collections.Concurrent;
+using Ploch.CommandLine.Spectre.SampleApp.Services.Models;
+
+namespace Ploch.CommandLine.Spectre.SampleApp.Services;
+
+/// <summary>
+///     In-memory implementation of <see cref="IUserService" /> for sample demonstrations.
+/// </summary>
+public class UserService : IUserService
+{
+    private readonly ConcurrentDictionary<int, UserProfile> _users = new();
+    private int _nextId = 1;
+
+    public UserService()
+    {
+        // Pre-populate with sample users
+        AddInternal(new UserProfile(1, "Alice Smith", "alice.smith@example.com", "Administrator", true, DateTime.UtcNow.AddDays(-30)));
+        AddInternal(new UserProfile(2, "Bob Jones", "bob.jones@example.com", "Developer", true, DateTime.UtcNow.AddDays(-15)));
+        AddInternal(new UserProfile(3, "Charlie Brown", "charlie.brown@example.com", "Contributor", false, DateTime.UtcNow.AddDays(-5)));
+        // The last seeded id: Interlocked.Increment returns the incremented value, so the first
+        // generated id is 4 and the sequence stays contiguous with the seed data.
+        _nextId = 3;
+    }
+
+    public Task<UserProfile> CreateUserAsync(string name, string email, string role, CancellationToken cancellationToken = default)
+    {
+        var id = Interlocked.Increment(ref _nextId);
+        var user = new UserProfile(id, name, email, role, true, DateTime.UtcNow);
+        _users[id] = user;
+
+        return Task.FromResult(user);
+    }
+
+    public Task<IEnumerable<UserProfile>> GetUsersAsync(bool activeOnly = false, CancellationToken cancellationToken = default)
+    {
+        var query = _users.Values.AsEnumerable();
+        if (activeOnly)
+        {
+            query = query.Where(u => u.IsActive);
+        }
+
+        return Task.FromResult<IEnumerable<UserProfile>>(query.OrderBy(u => u.Id).ToList());
+    }
+
+    public Task<bool> DeleteUserAsync(int id, CancellationToken cancellationToken = default)
+    {
+        var removed = _users.TryRemove(id, out _);
+
+        return Task.FromResult(removed);
+    }
+
+    private void AddInternal(UserProfile user)
+    {
+        _users[user.Id] = user;
+    }
+}

--- a/samples/SampleApp/src/SampleApp/Services/UserService.cs
+++ b/samples/SampleApp/src/SampleApp/Services/UserService.cs
@@ -24,6 +24,10 @@ public class UserService : IUserService
 
     public Task<UserProfile> CreateUserAsync(string name, string email, string role, CancellationToken cancellationToken = default)
     {
+        // A method that takes a token and never looks at it cannot be cancelled. Even a synchronous
+        // in-memory implementation checks it, so callers get the behaviour the signature promises.
+        cancellationToken.ThrowIfCancellationRequested();
+
         var id = Interlocked.Increment(ref _nextId);
         var user = new UserProfile(id, name, email, role, true, DateTime.UtcNow);
         _users[id] = user;
@@ -33,6 +37,8 @@ public class UserService : IUserService
 
     public Task<IEnumerable<UserProfile>> GetUsersAsync(bool activeOnly = false, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         var query = _users.Values.AsEnumerable();
         if (activeOnly)
         {
@@ -44,6 +50,8 @@ public class UserService : IUserService
 
     public Task<bool> DeleteUserAsync(int id, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         var removed = _users.TryRemove(id, out _);
 
         return Task.FromResult(removed);

--- a/samples/SampleApp/src/SampleApp/appsettings.json
+++ b/samples/SampleApp/src/SampleApp/appsettings.json
@@ -1,0 +1,17 @@
+{
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Warning",
+        "System": "Warning"
+      }
+    }
+  },
+  "SampleAppSettings": {
+    "Environment": "Development",
+    "DefaultOutputDirectory": "./output",
+    "MaxBatchSize": 100,
+    "EnableDiagnostics": true
+  }
+}

--- a/samples/SampleApp/tests/SampleApp.Tests/Commands/ConfigSetCommandTests.cs
+++ b/samples/SampleApp/tests/SampleApp.Tests/Commands/ConfigSetCommandTests.cs
@@ -1,0 +1,33 @@
+using FluentAssertions;
+using Moq;
+using Ploch.CommandLine.Spectre.Commands;
+using Ploch.CommandLine.Spectre.Output;
+using Ploch.CommandLine.Spectre.SampleApp.Commands.Config;
+using Spectre.Console.Cli;
+
+namespace Ploch.CommandLine.Spectre.SampleApp.Tests.Commands;
+
+public class ConfigSetCommandTests
+{
+    private readonly Mock<ICommandSettingsValidator<ConfigSetCommandSettings>> _validatorMock = new();
+    private readonly Mock<IExceptionHandler> _exceptionHandlerMock = new();
+    private readonly Mock<IOutput> _outputMock = new();
+
+    [Fact]
+    public void Execute_should_set_config_and_return_success()
+    {
+        var settings = new ConfigSetCommandSettings
+        {
+            Key = "TestKey",
+            Value = "TestValue",
+            Scope = "user"
+        };
+
+        var command = new ConfigSetCommand(_validatorMock.Object, _exceptionHandlerMock.Object, _outputMock.Object);
+        var context = new CommandContext([], Mock.Of<IRemainingArguments>(), "set", null);
+
+        var result = command.Execute(context, settings, CancellationToken.None);
+
+        result.Should().Be((int)ExitCode.Success);
+    }
+}

--- a/samples/SampleApp/tests/SampleApp.Tests/Commands/ConfigSetCommandTests.cs
+++ b/samples/SampleApp/tests/SampleApp.Tests/Commands/ConfigSetCommandTests.cs
@@ -13,21 +13,30 @@ public class ConfigSetCommandTests
     private readonly Mock<IExceptionHandler> _exceptionHandlerMock = new();
     private readonly Mock<IOutput> _outputMock = new();
 
-    [Fact]
-    public void Execute_should_set_config_and_return_success()
+    [Theory]
+    [InlineData("user")]
+    [InlineData("system")]
+    [InlineData("SYSTEM")]
+    public void Execute_should_return_success_for_a_supported_scope(string scope)
     {
-        var settings = new ConfigSetCommandSettings
-        {
-            Key = "TestKey",
-            Value = "TestValue",
-            Scope = "user"
-        };
+        var settings = new ConfigSetCommandSettings { Key = "TestKey", Value = "TestValue", Scope = scope };
 
-        var command = new ConfigSetCommand(_validatorMock.Object, _exceptionHandlerMock.Object, _outputMock.Object);
-        var context = new CommandContext([], Mock.Of<IRemainingArguments>(), "set", null);
-
-        var result = command.Execute(context, settings, CancellationToken.None);
+        var result = CreateCommand().Execute(CreateContext(), settings, CancellationToken.None);
 
         result.Should().Be((int)ExitCode.Success);
     }
+
+    [Fact]
+    public void Execute_should_return_invalid_input_for_an_unsupported_scope()
+    {
+        var settings = new ConfigSetCommandSettings { Key = "TestKey", Value = "TestValue", Scope = "machine" };
+
+        var result = CreateCommand().Execute(CreateContext(), settings, CancellationToken.None);
+
+        result.Should().Be((int)ExitCode.InvalidInput);
+    }
+
+    private static CommandContext CreateContext() => new([], Mock.Of<IRemainingArguments>(), "set", null);
+
+    private ConfigSetCommand CreateCommand() => new(_validatorMock.Object, _exceptionHandlerMock.Object, _outputMock.Object);
 }

--- a/samples/SampleApp/tests/SampleApp.Tests/Commands/FileProcessCommandTests.cs
+++ b/samples/SampleApp/tests/SampleApp.Tests/Commands/FileProcessCommandTests.cs
@@ -1,0 +1,55 @@
+using FluentAssertions;
+using Moq;
+using Ploch.CommandLine.Spectre.Commands;
+using Ploch.CommandLine.Spectre.Output;
+using Ploch.CommandLine.Spectre.SampleApp.Commands.Files;
+using Spectre.Console.Cli;
+
+namespace Ploch.CommandLine.Spectre.SampleApp.Tests.Commands;
+
+public class FileProcessCommandTests
+{
+    private readonly Mock<ICommandSettingsValidator<FileProcessCommandSettings>> _validatorMock = new();
+    private readonly Mock<IExceptionHandler> _exceptionHandlerMock = new();
+    private readonly Mock<IOutput> _outputMock = new();
+    private readonly CommandArgumentsRootProcessor _processor = new([new TokensArgumentsProcessor()]);
+
+    [Fact]
+    public async Task ExecuteAsync_should_expand_tokens_in_output_path()
+    {
+        var settings = new FileProcessCommandSettings
+        {
+            Path = "test.csv",
+            OutputPath = "./out-{date}/test.dat"
+        };
+
+        var command = new FileProcessCommand(_processor,
+                                             _validatorMock.Object,
+                                             _exceptionHandlerMock.Object,
+                                             _outputMock.Object);
+
+        var context = new CommandContext([], Mock.Of<IRemainingArguments>(), "process", null);
+
+        var result = await command.ExecuteAsync(context, settings, CancellationToken.None);
+
+        result.Should().Be((int)ExitCode.Success);
+        settings.OutputPath.Should().NotContain("{date}");
+        settings.OutputPath.Should().MatchRegex(@"\./out-\d{4}-\d{2}-\d{2}/test\.dat");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_should_report_cancelled_when_the_token_is_already_cancelled()
+    {
+        using var cancellationTokenSource = new CancellationTokenSource();
+        await cancellationTokenSource.CancelAsync();
+
+        var settings = new FileProcessCommandSettings { Path = "test.csv", OutputPath = "./out/test.dat" };
+
+        var command = new FileProcessCommand(_processor, _validatorMock.Object, _exceptionHandlerMock.Object, _outputMock.Object);
+
+        var result = await command.ExecuteAsync(new([], Mock.Of<IRemainingArguments>(), "process", null), settings, cancellationTokenSource.Token);
+
+        result.Should().Be((int)ExitCode.Cancelled);
+        _exceptionHandlerMock.Verify(h => h.HandleException(It.IsAny<Exception>()), Times.Never);
+    }
+}

--- a/samples/SampleApp/tests/SampleApp.Tests/Commands/FileReportCommandTests.cs
+++ b/samples/SampleApp/tests/SampleApp.Tests/Commands/FileReportCommandTests.cs
@@ -1,0 +1,49 @@
+using FluentAssertions;
+using Moq;
+using Ploch.CommandLine.Spectre.Commands;
+using Ploch.CommandLine.Spectre.Output;
+using Ploch.CommandLine.Spectre.SampleApp.Commands.Files;
+using Spectre.Console.Cli;
+
+namespace Ploch.CommandLine.Spectre.SampleApp.Tests.Commands;
+
+public class FileReportCommandTests
+{
+    private readonly Mock<ICommandSettingsValidator<FileReportCommandSettings>> _validatorMock = new();
+    private readonly Mock<IExceptionHandler> _exceptionHandlerMock = new();
+    private readonly Mock<IOutput> _outputMock = new();
+    private readonly CommandArgumentsRootProcessor _processor = new([]);
+
+    [Fact]
+    public async Task ExecuteAsync_should_return_invalid_input_when_the_file_does_not_exist()
+    {
+        var settings = new FileReportCommandSettings { Path = Path.Combine(Path.GetTempPath(), $"missing-{Guid.NewGuid():N}.csv") };
+
+        var result = await CreateCommand().ExecuteAsync(CreateContext(), settings, CancellationToken.None);
+
+        result.Should().Be((int)ExitCode.InvalidInput);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_should_return_success_for_an_existing_file()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"report-{Guid.NewGuid():N}.csv");
+        await File.WriteAllTextAsync(path, "id,name", TestContext.Current.CancellationToken);
+
+        try
+        {
+            var result = await CreateCommand().ExecuteAsync(CreateContext(), new FileReportCommandSettings { Path = path }, CancellationToken.None);
+
+            result.Should().Be((int)ExitCode.Success);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    private static CommandContext CreateContext() => new([], Mock.Of<IRemainingArguments>(), "report", null);
+
+    private FileReportCommand CreateCommand() =>
+        new(_processor, _validatorMock.Object, _exceptionHandlerMock.Object, _outputMock.Object);
+}

--- a/samples/SampleApp/tests/SampleApp.Tests/Commands/ProjectCreateCommandTests.cs
+++ b/samples/SampleApp/tests/SampleApp.Tests/Commands/ProjectCreateCommandTests.cs
@@ -1,0 +1,44 @@
+using FluentAssertions;
+using Moq;
+using Ploch.CommandLine.Spectre.Commands;
+using Ploch.CommandLine.Spectre.Output;
+using Ploch.CommandLine.Spectre.SampleApp.Commands.Projects;
+using Ploch.CommandLine.Spectre.SampleApp.Commands.Projects.UseCases;
+using Ploch.CommandLine.Spectre.SampleApp.Services;
+using Spectre.Console.Cli;
+
+namespace Ploch.CommandLine.Spectre.SampleApp.Tests.Commands;
+
+public class ProjectCreateCommandTests
+{
+    private readonly Mock<IOutput> _outputMock = new();
+    private readonly Mock<IProjectRepository> _projectRepositoryMock = new();
+    private readonly Mock<ICommandSettingsValidator<ProjectCreateCommandSettings>> _validatorMock = new();
+    private readonly Mock<IExceptionHandler> _exceptionHandlerMock = new();
+    private readonly CommandArgumentsRootProcessor _processor = new([]);
+
+    [Fact]
+    public async Task ExecuteAsync_should_execute_use_case_and_return_success()
+    {
+        var settings = new ProjectCreateCommandSettings
+        {
+            Name = "NewApp",
+            Description = "New application description",
+            Template = "Console"
+        };
+
+        var useCase = new CreateProjectUseCase(_projectRepositoryMock.Object);
+        var command = new ProjectCreateCommand(_outputMock.Object,
+                                             useCase,
+                                             _processor,
+                                             _validatorMock.Object,
+                                             _exceptionHandlerMock.Object);
+
+        var context = new CommandContext([], Mock.Of<IRemainingArguments>(), "create", null);
+
+        var result = await command.ExecuteAsync(context, settings, CancellationToken.None);
+
+        result.Should().Be((int)ExitCode.Success);
+        _projectRepositoryMock.Verify(r => r.AddAsync(It.Is<Services.Models.ProjectItem>(p => p.Name == "NewApp"), It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/samples/SampleApp/tests/SampleApp.Tests/Commands/UserAddCommandTests.cs
+++ b/samples/SampleApp/tests/SampleApp.Tests/Commands/UserAddCommandTests.cs
@@ -1,0 +1,47 @@
+using FluentAssertions;
+using Moq;
+using Ploch.CommandLine.Spectre.Commands;
+using Ploch.CommandLine.Spectre.Output;
+using Ploch.CommandLine.Spectre.SampleApp.Commands.Users;
+using Ploch.CommandLine.Spectre.SampleApp.Services;
+using Ploch.CommandLine.Spectre.SampleApp.Services.Models;
+using Spectre.Console.Cli;
+
+namespace Ploch.CommandLine.Spectre.SampleApp.Tests.Commands;
+
+public class UserAddCommandTests
+{
+    private readonly Mock<ICommandSettingsValidator<UserAddCommandSettings>> _validatorMock = new();
+    private readonly Mock<IExceptionHandler> _exceptionHandlerMock = new();
+    private readonly Mock<IOutput> _outputMock = new();
+    private readonly Mock<IUserService> _userServiceMock = new();
+    private readonly CommandArgumentsRootProcessor _processor = new([]);
+
+    [Fact]
+    public async Task ExecuteAsync_should_create_user_and_return_success()
+    {
+        var settings = new UserAddCommandSettings
+        {
+            Name = "John Doe",
+            Email = "john@example.com",
+            Role = "Developer"
+        };
+
+        var createdUser = new UserProfile(10, "John Doe", "john@example.com", "Developer", true, DateTime.UtcNow);
+        _userServiceMock.Setup(s => s.CreateUserAsync(settings.Name, settings.Email, settings.Role, It.IsAny<CancellationToken>()))
+                        .ReturnsAsync(createdUser);
+
+        var command = new UserAddCommand(_processor,
+                                         _validatorMock.Object,
+                                         _exceptionHandlerMock.Object,
+                                         _outputMock.Object,
+                                         _userServiceMock.Object);
+
+        var context = new CommandContext([], Mock.Of<IRemainingArguments>(), "add", null);
+
+        var result = await command.ExecuteAsync(context, settings, CancellationToken.None);
+
+        result.Should().Be((int)ExitCode.Success);
+        _userServiceMock.Verify(s => s.CreateUserAsync("John Doe", "john@example.com", "Developer", It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/samples/SampleApp/tests/SampleApp.Tests/Commands/UserDeleteCommandTests.cs
+++ b/samples/SampleApp/tests/SampleApp.Tests/Commands/UserDeleteCommandTests.cs
@@ -1,0 +1,51 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Ploch.CommandLine.Spectre.Commands;
+using Ploch.CommandLine.Spectre.Output;
+using Ploch.CommandLine.Spectre.SampleApp.Commands.Users;
+using Ploch.CommandLine.Spectre.SampleApp.Services;
+using Spectre.Console.Cli;
+
+namespace Ploch.CommandLine.Spectre.SampleApp.Tests.Commands;
+
+public class UserDeleteCommandTests
+{
+    private readonly Mock<ICommandSettingsValidator<UserDeleteCommandSettings>> _validatorMock = new();
+    private readonly Mock<IExceptionHandler> _exceptionHandlerMock = new();
+    private readonly Mock<IOutput> _outputMock = new();
+    private readonly Mock<IUserService> _userServiceMock = new();
+    private readonly CommandArgumentsRootProcessor _processor = new([]);
+
+    [Fact]
+    public async Task ExecuteAsync_should_return_success_when_the_user_was_deleted()
+    {
+        using var cancellationTokenSource = new CancellationTokenSource();
+        _userServiceMock.Setup(s => s.DeleteUserAsync(7, cancellationTokenSource.Token)).ReturnsAsync(true);
+
+        var result = await CreateCommand().ExecuteAsync(CreateContext(), new UserDeleteCommandSettings { Id = 7 }, cancellationTokenSource.Token);
+
+        result.Should().Be((int)ExitCode.Success);
+        _userServiceMock.Verify(s => s.DeleteUserAsync(7, cancellationTokenSource.Token), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_should_return_error_when_the_user_does_not_exist()
+    {
+        _userServiceMock.Setup(s => s.DeleteUserAsync(99, It.IsAny<CancellationToken>())).ReturnsAsync(false);
+
+        var result = await CreateCommand().ExecuteAsync(CreateContext(), new UserDeleteCommandSettings { Id = 99 }, CancellationToken.None);
+
+        result.Should().Be((int)ExitCode.Error);
+    }
+
+    private static CommandContext CreateContext() => new([], Mock.Of<IRemainingArguments>(), "delete", null);
+
+    private UserDeleteCommand CreateCommand() =>
+        new(_processor,
+            _validatorMock.Object,
+            _exceptionHandlerMock.Object,
+            _outputMock.Object,
+            _userServiceMock.Object,
+            NullLogger<UserDeleteCommand>.Instance);
+}

--- a/samples/SampleApp/tests/SampleApp.Tests/Commands/UserDeleteCommandTests.cs
+++ b/samples/SampleApp/tests/SampleApp.Tests/Commands/UserDeleteCommandTests.cs
@@ -23,7 +23,9 @@ public class UserDeleteCommandTests
         using var cancellationTokenSource = new CancellationTokenSource();
         _userServiceMock.Setup(s => s.DeleteUserAsync(7, cancellationTokenSource.Token)).ReturnsAsync(true);
 
-        var result = await CreateCommand().ExecuteAsync(CreateContext(), new UserDeleteCommandSettings { Id = 7 }, cancellationTokenSource.Token);
+        var result = await CreateCommand().ExecuteAsync(CreateContext(),
+                                                        new UserDeleteCommandSettings { Id = 7, Force = true },
+                                                        cancellationTokenSource.Token);
 
         result.Should().Be((int)ExitCode.Success);
         _userServiceMock.Verify(s => s.DeleteUserAsync(7, cancellationTokenSource.Token), Times.Once);
@@ -34,9 +36,22 @@ public class UserDeleteCommandTests
     {
         _userServiceMock.Setup(s => s.DeleteUserAsync(99, It.IsAny<CancellationToken>())).ReturnsAsync(false);
 
-        var result = await CreateCommand().ExecuteAsync(CreateContext(), new UserDeleteCommandSettings { Id = 99 }, CancellationToken.None);
+        var result = await CreateCommand().ExecuteAsync(CreateContext(),
+                                                        new UserDeleteCommandSettings { Id = 99, Force = true },
+                                                        CancellationToken.None);
 
         result.Should().Be((int)ExitCode.Error);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_should_refuse_to_delete_without_force_when_the_console_cannot_confirm()
+    {
+        // The test host has no interactive console, which is the same situation as a CI pipeline:
+        // the command must refuse rather than delete unprompted.
+        var result = await CreateCommand().ExecuteAsync(CreateContext(), new UserDeleteCommandSettings { Id = 7 }, CancellationToken.None);
+
+        result.Should().Be((int)ExitCode.InvalidInput);
+        _userServiceMock.Verify(s => s.DeleteUserAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     private static CommandContext CreateContext() => new([], Mock.Of<IRemainingArguments>(), "delete", null);

--- a/samples/SampleApp/tests/SampleApp.Tests/Commands/UserListCommandTests.cs
+++ b/samples/SampleApp/tests/SampleApp.Tests/Commands/UserListCommandTests.cs
@@ -1,0 +1,60 @@
+using FluentAssertions;
+using Moq;
+using Ploch.CommandLine.Spectre.Commands;
+using Ploch.CommandLine.Spectre.Output;
+using Ploch.CommandLine.Spectre.SampleApp.Commands.Users;
+using Ploch.CommandLine.Spectre.SampleApp.Services;
+using Ploch.CommandLine.Spectre.SampleApp.Services.Models;
+using Spectre.Console.Cli;
+
+namespace Ploch.CommandLine.Spectre.SampleApp.Tests.Commands;
+
+public class UserListCommandTests
+{
+    private readonly Mock<ICommandSettingsValidator<UserListCommandSettings>> _validatorMock = new();
+    private readonly Mock<IExceptionHandler> _exceptionHandlerMock = new();
+    private readonly Mock<IOutput> _outputMock = new();
+    private readonly Mock<IUserService> _userServiceMock = new();
+    private readonly CommandArgumentsRootProcessor _processor = new([]);
+
+    [Fact]
+    public async Task ExecuteAsync_should_return_invalid_input_when_the_format_is_not_supported()
+    {
+        var settings = new UserListCommandSettings { Format = "xml" };
+
+        var result = await CreateCommand().ExecuteAsync(CreateContext(), settings, CancellationToken.None);
+
+        result.Should().Be((int)ExitCode.InvalidInput);
+        _userServiceMock.Verify(s => s.GetUsersAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_should_forward_the_cancellation_token_to_the_user_service()
+    {
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var settings = new UserListCommandSettings { Format = "compact" };
+        _userServiceMock.Setup(s => s.GetUsersAsync(false, cancellationTokenSource.Token))
+                        .ReturnsAsync([new UserProfile(1, "Alice Smith", "alice@example.com", "Developer", true, DateTime.UtcNow)]);
+
+        var result = await CreateCommand().ExecuteAsync(CreateContext(), settings, cancellationTokenSource.Token);
+
+        result.Should().Be((int)ExitCode.Success);
+        _userServiceMock.Verify(s => s.GetUsersAsync(false, cancellationTokenSource.Token), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_should_report_success_when_no_users_match()
+    {
+        var settings = new UserListCommandSettings { ActiveOnly = true };
+        _userServiceMock.Setup(s => s.GetUsersAsync(true, It.IsAny<CancellationToken>())).ReturnsAsync([]);
+
+        var result = await CreateCommand().ExecuteAsync(CreateContext(), settings, CancellationToken.None);
+
+        result.Should().Be((int)ExitCode.Success);
+    }
+
+    private static CommandContext CreateContext() => new([], Mock.Of<IRemainingArguments>(), "list", null);
+
+    private UserListCommand CreateCommand() =>
+        new(_processor, _validatorMock.Object, _exceptionHandlerMock.Object, _outputMock.Object, _userServiceMock.Object);
+}

--- a/samples/SampleApp/tests/SampleApp.Tests/Ploch.CommandLine.Spectre.SampleApp.Tests.csproj
+++ b/samples/SampleApp/tests/SampleApp.Tests/Ploch.CommandLine.Spectre.SampleApp.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Ardalis.Result" />
     <PackageReference Include="AutoFixture" />
     <PackageReference Include="AutoFixture.AutoMoq" />
     <PackageReference Include="AutoFixture.Xunit3" />

--- a/samples/SampleApp/tests/SampleApp.Tests/Ploch.CommandLine.Spectre.SampleApp.Tests.csproj
+++ b/samples/SampleApp/tests/SampleApp.Tests/Ploch.CommandLine.Spectre.SampleApp.Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(TargetFrameworkVersion)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Ploch.CommandLine.Spectre.SampleApp.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AutoFixture" />
+    <PackageReference Include="AutoFixture.AutoMoq" />
+    <PackageReference Include="AutoFixture.Xunit3" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="coverlet.collector" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\SampleApp\Ploch.CommandLine.Spectre.SampleApp.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/SampleApp/tests/SampleApp.Tests/UseCases/ExportProjectUseCaseTests.cs
+++ b/samples/SampleApp/tests/SampleApp.Tests/UseCases/ExportProjectUseCaseTests.cs
@@ -1,0 +1,48 @@
+using FluentAssertions;
+using Moq;
+using Ploch.CommandLine.Spectre.SampleApp.Commands.Projects.UseCases;
+using Ploch.CommandLine.Spectre.SampleApp.Services;
+using Ploch.CommandLine.Spectre.SampleApp.Services.Models;
+
+namespace Ploch.CommandLine.Spectre.SampleApp.Tests.UseCases;
+
+public class ExportProjectUseCaseTests
+{
+    private readonly Mock<IProjectRepository> _projectRepositoryMock = new();
+
+    [Fact]
+    public async Task ExecuteAsync_should_write_a_manifest_for_an_existing_project()
+    {
+        var outputPath = Path.Combine(Path.GetTempPath(), $"export-{Guid.NewGuid():N}");
+        var project = new ProjectItem("SpectreDemo", "Demo project", "Console", DateTime.UtcNow);
+        _projectRepositoryMock.Setup(r => r.GetByNameAsync("SpectreDemo", It.IsAny<CancellationToken>())).ReturnsAsync(project);
+
+        try
+        {
+            var result = await new ExportProjectUseCase(_projectRepositoryMock.Object)
+                .ExecuteAsync(new ExportProjectRequest("SpectreDemo", outputPath), CancellationToken.None);
+
+            result.IsSuccess.Should().BeTrue();
+            File.Exists(result.Value.OutputPath).Should().BeTrue();
+            (await File.ReadAllTextAsync(result.Value.OutputPath, TestContext.Current.CancellationToken)).Should().Contain("SpectreDemo");
+        }
+        finally
+        {
+            if (Directory.Exists(outputPath))
+            {
+                Directory.Delete(outputPath, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_should_report_not_found_for_an_unknown_project()
+    {
+        _projectRepositoryMock.Setup(r => r.GetByNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync((ProjectItem?)null);
+
+        var result = await new ExportProjectUseCase(_projectRepositoryMock.Object)
+            .ExecuteAsync(new ExportProjectRequest("Missing", Path.GetTempPath()), CancellationToken.None);
+
+        result.Status.Should().Be(Ardalis.Result.ResultStatus.NotFound);
+    }
+}

--- a/samples/SampleApp/tests/SampleApp.Tests/Validation/UserAddCommandSettingsValidatorTests.cs
+++ b/samples/SampleApp/tests/SampleApp.Tests/Validation/UserAddCommandSettingsValidatorTests.cs
@@ -1,0 +1,82 @@
+using FluentAssertions;
+using Ploch.CommandLine.Spectre.SampleApp.Commands.Users;
+using Ploch.CommandLine.Spectre.SampleApp.Commands.Users.Validators;
+
+namespace Ploch.CommandLine.Spectre.SampleApp.Tests.Validation;
+
+public class UserAddCommandSettingsValidatorTests
+{
+    private readonly UserAddCommandSettingsValidator _validator = new();
+
+    [Fact]
+    public void Validate_should_succeed_when_settings_are_valid()
+    {
+        var settings = new UserAddCommandSettings
+        {
+            Name = "John Doe",
+            Email = "john.doe@example.com",
+            Role = "Developer"
+        };
+
+        var result = _validator.Validate(settings);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("A")]
+    public void Validate_should_fail_when_name_is_invalid(string name)
+    {
+        var settings = new UserAddCommandSettings
+        {
+            Name = name,
+            Email = "john@example.com",
+            Role = "Developer"
+        };
+
+        var result = _validator.Validate(settings);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(UserAddCommandSettings.Name));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-an-email")]
+    [InlineData("@missing-user.com")]
+    public void Validate_should_fail_when_email_is_invalid(string email)
+    {
+        var settings = new UserAddCommandSettings
+        {
+            Name = "Valid Name",
+            Email = email,
+            Role = "Developer"
+        };
+
+        var result = _validator.Validate(settings);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(UserAddCommandSettings.Email));
+    }
+
+    [Theory]
+    [InlineData("SuperAdmin")]
+    [InlineData("Guest")]
+    [InlineData("Invalid")]
+    public void Validate_should_fail_when_role_is_not_allowed(string role)
+    {
+        var settings = new UserAddCommandSettings
+        {
+            Name = "Valid Name",
+            Email = "valid@example.com",
+            Role = role
+        };
+
+        var result = _validator.Validate(settings);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(UserAddCommandSettings.Role));
+    }
+}


### PR DESCRIPTION
## Describe your changes

Adds the sample application and getting-started documentation that issue #9 asks for.

> ⚠️ **Stacked PR.** The base branch is `build/7-nbgv-versioning-nuget-publish` (PR #17), **not**
> `main`. That branch carries the `Ploch.CommandLine.Spectre.FluentValidation` project rename and
> the rewritten `build-dotnet.yml` that this PR builds on. Merge #17 first; this PR then retargets
> to `main` on its own.

### Summary

| Item | Where |
|---|---|
| Runnable sample CLI | `samples/SampleApp/` |
| Hands-on walkthrough | `docs/GETTING_STARTED.md` (new `docs/` folder) |
| Sample tour with real output | `samples/SampleApp/README.md` |
| Samples index | `samples/README.md` |
| CI guard | `Build sample application` step in `build-dotnet.yml` |

The sample covers everything issue #9 lists: application configuration, `CommandSettings` and
commands, and a composite CLI with four branches (`user`, `config`, `file`, `project`), each with
its own sub-commands and options.

### Changes

**Sample application (`samples/SampleApp/`)**

- Follows the `ploch-data` `samples/SampleApp/` convention: standalone `.slnx`, its own
  `Directory.Build.props` / `Directory.Build.targets` / `Directory.Packages.props` / `ProjectReferences.props`, `src/`, `tests/`.
  (The working copy this started from was an uncommitted, never-built directory named
  `samples/from-gemini` — renamed, finished and made to compile.)
- Demonstrates `AppBuilder`, DI and `IConfiguration`, `AppCommand<T>` / `AsyncAppCommand<T>` /
  `UseCaseAsyncCommand<,,,>`, FluentValidation, `[SupportsTokens]`, Serilog, `ILogger<T>`,
  cancellation, and the full `ExitCode` range.
- 28 unit tests (xUnit v3, FluentAssertions, Moq) — exit codes, token expansion, cancellation
  handling, input validation, the written export artefact, use case invocation, validator rules.

**Compilation fixes — API drift since PR #11**

Four commands overrode `DoExecuteAsync(CommandContext, TSettings)`; the abstract member now takes a
`CancellationToken`. Signatures updated in `UserListCommand`, `UserAddCommand`, `UserDeleteCommand`
and `FileProcessCommand` — and, in each, **the token is actually forwarded** (to the service calls
and to `Task.Delay` inside the spinner) rather than accepted and discarded. The docs claim only what
the code does.

**Renamed package**

`PlochCommandLine.Spectre.FluentValidation` → `Ploch.CommandLine.Spectre.FluentValidation`
throughout (`Directory.Packages.props`, `ProjectReferences.props`, the app `.csproj`, `Program.cs`,
docs). Verified against the source: the assembly name **and** the C# namespace are both
`Ploch.CommandLine.Spectre.FluentValidation`, so the `using` needed changing too.

**Defects found by running the application**

These were found during manual verification, not by review — each is a real bug in the sample as it
stood:

1. **`config show` leaked the environment.** It enumerated `configuration.GetChildren()`. The host
   adds an environment-variable provider, so the command printed every environment variable of the
   process — on my machine that included GitHub PATs and API keys. It now renders an allow-list of
   the application's own sections, and the code comment explains why an allow-list is the point of
   the example.
2. **Configuration was working-directory dependent.** `appsettings.json` resolved against the cwd,
   so running the tool from anywhere other than its own folder made every setting read back `null`
   (`info` showed `Environment Setting: Not configured`). The base path is now
   `AppContext.BaseDirectory`, with `optional: false` so a missing file fails loudly.
3. **`GlobalSettings` was dead code** — a `-v|--verbose` option declared and never wired to
   anything. It is now the shared base for the three `user` settings classes and is honoured in all
   three commands, which is a better demonstration than deleting it.
4. **Generated user IDs skipped 4** (seed data 1–3, first generated ID 5).
5. **Serilog was referenced and documented but never registered.** Now wired via
   `services.AddSerilog(...)`, with `ILogger<UserDeleteCommand>` used alongside `IOutput`.

**Review findings addressed (commit `ff8df34`)**

CodeAnt and Codex raised 12 review threads; all 12 were valid, all are fixed and every thread has an
evidence-backed reply and is resolved.

- **P1, MSBuild evaluation order (Codex).** Confirmed with
  `dotnet msbuild … -p:UsePlochProjectReferences=true -getItem:PackageReference`: the project carried
  **both** the six `Ploch.*` package references and the six project references, because
  `Directory.Build.props` is evaluated before the project body and the `Remove` items had nothing to
  remove. It only built because NuGet gives a project reference precedence over a package reference
  of the same ID. The import now lives in a new `Directory.Build.targets` (evaluated *after* the
  project body); the same query now returns no `Ploch.*` packages.
- **Markup injection.** Every value from outside the source — user input, paths, configuration
  values — is escaped with `Markup.Escape` before reaching a `Table`, `Panel`, `Tree` or `Markup`.
  `user add "Alice [Admin] Smith"` previously threw *after* creating the account; it now renders the
  name literally.
- **Static `AnsiConsole`.** Renderables now go through `IOutput.Write(IRenderable)`, keeping the
  commands testable. (One exception, flagged on the thread: `FileProcessCommand`'s spinner, because
  `IOutput` has no live-display API.)
- **`config set` claimed a change it never made.** It now validates `--scope` (→ `InvalidInput` for
  anything but `user`/`system`) and states that it previews rather than persists. A writable provider
  would not have fixed it — each invocation is a new process, so the next `config get` still could
  not observe the write.
- **`file report` declared any path analysed.** Now checks the file exists (→ `InvalidInput`) and
  reports its real size and last-write time.
- **`project export` returned success having written nothing.** Now writes `<Project>.json` into the
  output directory and turns I/O failure into a failed `Result`.
- **`--force` was decorative.** `user delete` now prompts on an interactive console, and refuses with
  `InvalidInput` where nothing can answer. Declining the prompt is `Cancelled` — the two refusals are
  deliberately different codes.
- **Services ignored their `CancellationToken`.** All six now call `ThrowIfCancellationRequested()`.

**Warnings**

Sample builds with **0 warnings** without widening the sample's `NoWarn`:

- 3 × `CS9107` (`IOutput` captured *and* passed to the base constructor) — fixed by using the
  inherited `Output` property.
- 1 × `MSB3277` (`Microsoft.Bcl.AsyncInterfaces` 6.0.0 from `xunit.v3.common` vs 10.0.5 elsewhere)
  — fixed properly with `CentralPackageTransitivePinningEnabled` plus a pinned `PackageVersion`,
  not suppressed.
- 2 × `xUnit1051` in the new tests (a `CancellationToken` overload called without
  `TestContext.Current.CancellationToken`) — fixed. Note these only appear on a non-incremental
  build; `dotnet build --no-incremental -c Release` is the check that catches them.

**CI**

New `Build sample application` step running
`dotnet build ./samples/SampleApp/Ploch.CommandLine.Spectre.SampleApp.slnx -c Release -p:UsePlochProjectReferences=true`.
Not `continue-on-error`. Nothing else in the workflow was touched.

## Design Decisions

- **Location `samples/SampleApp/`** — issue #9 says to follow `ploch-data`, whose sample lives at
  `samples/SampleApp/` with exactly this file set. Inner directories shortened to `src/SampleApp/`
  and `tests/SampleApp.Tests/` to match both `ploch-data`'s short inner names and this workspace's
  `project-structure.md` (directory = short name, project file keeps the full `Ploch.*` name).
  Directory depth is unchanged, so the `$(MSBuildThisFileDirectory)..\..\` hops in
  `ProjectReferences.props` still resolve.
- **Standalone-by-`PackageReference` design preserved.** Per `.claude/rules/sample-apps.md` the
  sample must work in isolation. Default mode therefore uses `PackageReference` — which **cannot
  restore today**, because the `Ploch.CommandLine.*` packages are not published yet (issue #7).
  That is stated plainly in the sample README rather than papered over; CI and all verification
  below use `-p:UsePlochProjectReferences=true`.
- **CI step placed after `SonarScanner End`.** The scanner captures every MSBuild project built
  between begin and end; the sample is deliberately outside `SOLUTION_PATH` and already sits in
  `sonar.coverage.exclusions`, so building it inside the Sonar window would pull sample code into
  analysis and could fail the quality gate on unrelated PRs.
- **Sample tests are not run in CI, only built.** Their TRX and coverage files would be picked up
  by the existing `**/CoverageResults/*` and `**/*.trx` globs and skew the reported coverage of the
  libraries. Happy to add a separately-scoped test step if you would rather have it.
- **The `-1` exit code is documented, not hidden.** A failed FluentValidation `Validate` is reported
  by `Spectre.Console.Cli` itself and short-circuits with `-1` — *not* with `ExitCode.InvalidInput`.
  Rather than write a false claim, the docs state this, and `user list -f xml` was added as a place
  where a command genuinely returns `ExitCode.InvalidInput` (verified: exit code 2).
- **`docs/GETTING_STARTED.md` is a hands-on walkthrough**, deliberately not overlapping
  `DocumentationSite/index.md` / `articles/intro.md` from PR #16 — it builds a CLI step by step and
  cross-links to them for the conceptual material. No docfx config was touched; PR #16 includes
  `../docs/**/*.md`.

## Testing

### Automated

```
dotnet build samples/SampleApp/Ploch.CommandLine.Spectre.SampleApp.slnx -p:UsePlochProjectReferences=true
  → Build succeeded. 0 Warning(s) 0 Error(s)

dotnet build samples/SampleApp/Ploch.CommandLine.Spectre.SampleApp.slnx -c Release -p:UsePlochProjectReferences=true
  → Build succeeded. 0 Warning(s) 0 Error(s)      (exactly what the new CI step runs)

dotnet build samples/SampleApp/Ploch.CommandLine.Spectre.SampleApp.slnx -c Release --no-incremental -p:UsePlochProjectReferences=true
  → Build succeeded. 0 Warning(s) 0 Error(s)      (forced rebuild, so nothing is hidden by incrementality)

dotnet test samples/SampleApp/Ploch.CommandLine.Spectre.SampleApp.slnx -p:UsePlochProjectReferences=true
  → Passed! Failed: 0, Passed: 28, Skipped: 0, Total: 28

dotnet build ./Ploch.CommandLine.Spectre.slnx -c Release
  → Build succeeded. 0 Warning(s) 0 Error(s)

dotnet test ./Ploch.CommandLine.Spectre.slnx -c Release --no-build
  → Ploch.CommandLine.Spectre.Tests                  74 passed
  → Ploch.CommandLine.Spectre.FluentValidation.Tests  1 passed
  → (plus the ploch-common projects in the solution: 830 + 863 + 15 + 6, all passed)
```

The workflow YAML was parsed after editing (`yaml.safe_load`) — 25 steps, valid.

### Manual verification

Real captured output, `NO_COLOR=1`, FIGlet banner trimmed. Exit codes are `$LASTEXITCODE`.

```text
$ sample --help

USAGE:
    sample [OPTIONS] <COMMAND>

EXAMPLES:
    sample info
    sample info -d
    sample user add Alice Smith -e alice@example.com -r Administrator
    sample user list
    sample user list -a -f compact

OPTIONS:
    -h, --help    Prints help information

COMMANDS:
    info       Display system, application, and host runtime information
    user       Manage user accounts and profile data
    config     Inspect and manage application configuration settings
    file       File processing and report generation utilities
    project    Project operations powered by Clean Architecture use cases and
               Ardalis.Result

[exit code: 0]
```

```text
$ sample info

=== Application & System Information ===

╭──────────────────────┬────────────────────────────────────────────╮
│ Property             │ Value                                      │
├──────────────────────┼────────────────────────────────────────────┤
│ Application Name     │ Ploch.CommandLine.Spectre Sample App       │
│ Framework            │ .NET 10.0.11                               │
│ OS Description       │ Microsoft Windows 10.0.26200               │
│ Process Architecture │ X64                                        │
│ Current Directory    │ C:\DevNet\my\mrploch\ploch-commandline-wt9 │
│ Machine Name         │ KPLOCH-MSI                                 │
│ Environment Setting  │ Development                                │
╰──────────────────────┴────────────────────────────────────────────╯

Command completed successfully.

[exit code: 0]
```

```text
$ sample user add "Alice Smith" -e alice@example.com -r Administrator

Executing command UserAddCommandSettings

Processing arguments...
Creating new user account for Alice Smith...
╭─User Created Successfully────────╮
│ User ID: 4                       │
│ Name: Alice Smith                │
│ Email: alice@example.com         │
│ Role: Administrator              │
│ Active: Yes                      │
│ Created: 2026-08-22 12:37:59 UTC │
╰──────────────────────────────────╯

[exit code: 0]
```

```text
$ sample config show

Application Configuration Settings

Configuration
├── SampleAppSettings
│   ├── DefaultOutputDirectory
│   │   └── Value: ./output
│   ├── EnableDiagnostics
│   │   └── Value: True
│   ├── Environment
│   │   └── Value: Development
│   └── MaxBatchSize
│       └── Value: 100
└── Serilog
    └── MinimumLevel
        ├── Default
        │   └── Value: Information
        └── Override
            ├── Microsoft
            │   └── Value: Warning
            └── System
                └── Value: Warning

[exit code: 0]
```

Before the fix this same command printed ~90 further nodes, one per environment variable, secrets
included.

```text
$ sample file process dataset.csv -o "./out-{date}/result.dat"

Executing command FileProcessCommandSettings

Processing arguments...
Processing File: dataset.csv
Resolved Output Path (with tokens replaced): ./out-2026-08-22/result.dat
Backup enabled: True

Processing file content...
File processed successfully!
Saved result to: ./out-2026-08-22/result.dat

[exit code: 0]
```

```text
$ sample project create MicroserviceDemo -d "Cloud native backend" -t WebAPI

Starting use case CreateProjectUseCase
Settings:
Name: MicroserviceDemo
Description: Cloud native backend
Template: WebAPI
Use case completed successfully.

[exit code: 0]
```

```text
$ sample project create SpectreDemo

Starting use case CreateProjectUseCase
Settings:
Name: SpectreDemo
Description: Sample project
Template: Console
Use case failed: A project with name 'SpectreDemo' already exists.

[exit code: 1]
```

Failure paths and exit codes:

```text
$ sample user add "A" -e "invalid-email"

Error: User name must be at least 2 characters long.
A valid email address must be provided.

[exit code: -1]        # Spectre.Console.Cli's own validation short-circuit
```

```text
$ sample user list -f xml

Executing command UserListCommandSettings

Processing arguments...
Unsupported format 'xml'. Supported formats: table, compact.

[exit code: 2]         # ExitCode.InvalidInput, returned by the command
```

```text
$ sample user delete 1

Refusing to delete user 1 without confirmation. Re-run with --force.

[exit code: 2]         # ExitCode.InvalidInput - nothing can answer a prompt here
```

```text
$ sample user delete 1 --force

Deleting user with ID: 1 (force: True)...
User 1 deleted successfully.

[exit code: 0]
```

```text
$ sample user delete 99 --force

Deleting user with ID: 99 (force: True)...
User with ID 99 was not found.

[exit code: 1]         # ExitCode.Error
```

```text
$ sample config set SampleAppSettings:MaxBatchSize 250 -s machine

Unsupported scope 'machine'. Supported scopes: user, system.

[exit code: 2]
```

```text
$ sample file report missing.csv

File 'missing.csv' was not found.

[exit code: 2]
```

Markup escaping, verified with a name that previously broke the render:

```text
$ sample user add "Alice [Admin] Smith" -e alice@example.com -r Administrator

╭─User Created Successfully────────╮
│ User ID: 4                       │
│ Name: Alice [Admin] Smith        │
│ Email: alice@example.com         │
│ Role: Administrator              │
│ Active: Yes                      │
│ Created: 2026-08-22 12:59:47 UTC │
╰──────────────────────────────────╯

[exit code: 0]
```

The export now produces the artefact it reports (run from a scratch directory):

```text
$ sample project export SpectreDemo -o "./exports-{date}"
Use case completed successfully.

$ cat exports-2026-08-22/SpectreDemo.json
{
  "Name": "SpectreDemo",
  "Description": "Demo project for Spectre Console CLI",
  "Template": "Console",
  "CreatedAt": "2026-08-12T13:01:26.0404929Z"
}
```

Serilog output written by that last run:

```text
$ cat logs/sample.log
2026-08-22 14:36:16.690 +02:00 [WRN] [UserDeleteCommand] Delete requested for unknown user 99

$ cat logs/sample-errors.log
[14:36:16 WRN] [Ploch.CommandLine.Spectre.SampleApp.Commands.Users.UserDeleteCommand] [UserDeleteCommand] Delete requested for unknown user 99
```

Inherited option, verified in help and in behaviour:

```text
$ sample user list --help

OPTIONS:
                             DEFAULT
    -h, --help                          Prints help information
    -v, --verbose                       Enable verbose console output
    -a, --active-only                   Only display active user accounts
    -f, --format <FORMAT>    table      The output format: 'table' or 'compact'

$ sample user list -v -f compact -a

Verbose: format='compact', active only='True'.
Retrieving users (active only: True)...
[1] Alice Smith <alice.smith@example.com> (Administrator) - Active: True
[2] Bob Jones <bob.jones@example.com> (Developer) - Active: True

Total users: 2

[exit code: 0]
```

## Open questions for the reviewer

1. **Sample tests in CI** — built but not run, for the coverage-glob reason above. Add a scoped test
   step?
2. **`config get` still reads the whole configuration**, so `config get PATH` prints the
   environment variable. That is an explicit single-key lookup rather than a bulk dump, so it was
   left as is — say the word and it can be restricted to the same allow-list.
   (`config show`, the bulk dump, *is* restricted.)
3. **The `-1` validation exit code** could be mapped onto `ExitCode.InvalidInput` with a custom
   Spectre exception handler. That felt like it belonged in the library rather than in a sample, so
   it is documented instead.

## Issue ticket number and link

Closes #9

Related: #7 (package publishing — required before the sample's default `PackageReference` mode can
restore), #11 (the `CancellationToken` API change this fixes the sample against), #15 (deletes the
legacy McMaster samples — untouched here), #16 (docs site; picks up `docs/**/*.md` automatically).

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests. (20 tests, covering the behaviour
      changed here — exit codes, token expansion, cancellation)
- [ ] Do we need to implement analytics? — n/a
- [x] Will this be part of a product update? If yes, please write one phrase about this update.
      *"`Ploch.CommandLine.Spectre` now ships a runnable sample application and a getting-started
      guide."*
