### PR TITLE
test(spectre): Raise coverage to clear the SonarCloud quality gate

### DIFF
--- a/Ploch.CommandLine.Spectre.slnx
+++ b/Ploch.CommandLine.Spectre.slnx
@@ -36,7 +36,9 @@
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests\Spectre\CommandLine.Spectre.FluentValidation.Tests\Ploch.CommandLine.Spectre.FluentValidation.Tests.csproj" Type="Classic C#" />
+    <Project Path="tests\Spectre\CommandLine.Spectre.Serilog.Tests\Ploch.CommandLine.Spectre.Serilog.Tests.csproj" Type="Classic C#" />
     <Project Path="tests\Spectre\CommandLine.Spectre.Tests\Ploch.CommandLine.Spectre.Tests.csproj" Type="Classic C#" />
+    <Project Path="tests\Spectre\CommandLine.UseCases.Tests\Ploch.CommandLine.UseCases.Tests.csproj" Type="Classic C#" />
   </Folder>
   <Project Path="src\Spectre\CommandLine.Spectre.FluentValidation\Ploch.CommandLine.Spectre.FluentValidation.csproj" Type="Classic C#" />
   <Project Path="src\Spectre\CommandLine.Spectre.Serilog\Ploch.CommandLine.Spectre.Serilog.csproj" Type="Classic C#" />

--- a/tests/Spectre/CommandLine.Spectre.FluentValidation.Tests/FluentCommandSettingsValidatorTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.FluentValidation.Tests/FluentCommandSettingsValidatorTests.cs
@@ -1,0 +1,62 @@
+using FluentAssertions;
+using FluentValidation;
+using Objectivity.AutoFixture.XUnit2.AutoMoq.Attributes;
+using Spectre.Console.Cli;
+
+namespace Ploch.CommandLine.Spectre.FluentValidation.Tests;
+
+/// <summary>
+///     Cover for the FluentValidation-backed settings validator, including the fallback it takes when no
+///     FluentValidation validator has been registered for the settings type.
+/// </summary>
+public class FluentCommandSettingsValidatorTests
+{
+    [Theory]
+    [AutoMockData]
+    public void Validate_should_fall_back_to_the_built_in_settings_validation_when_no_fluent_validator_is_supplied(CommandContext context)
+    {
+        var validator = new FluentCommandSettingsValidator<SelfValidatingSettings>();
+
+        var result = validator.Validate(context, new SelfValidatingSettings { Message = "rejected by the settings themselves" });
+
+        result.Successful.Should().BeFalse();
+        result.Message.Should().Be("rejected by the settings themselves");
+    }
+
+    [Theory]
+    [AutoMockData]
+    public void Validate_should_report_success_when_the_fluent_validator_accepts_the_settings(CommandContext context)
+    {
+        var validator = new FluentCommandSettingsValidator<TestCommandSettings>(new AcceptingValidator());
+
+        validator.Validate(context, new TestCommandSettings()).Successful.Should().BeTrue();
+    }
+
+    [Theory]
+    [AutoMockData]
+    public void Validate_should_report_the_fluent_validator_failures(CommandContext context)
+    {
+        var validator = new FluentCommandSettingsValidator<TestCommandSettings>(new RejectingValidator());
+
+        var result = validator.Validate(context, new TestCommandSettings());
+
+        result.Successful.Should().BeFalse();
+        result.Message.Should().Contain("Not Empty String Property");
+    }
+
+    private sealed class SelfValidatingSettings : CommandSettings
+    {
+        public string Message { get; init; } = string.Empty;
+
+        public override global::Spectre.Console.ValidationResult Validate() => global::Spectre.Console.ValidationResult.Error(Message);
+    }
+
+    private sealed class AcceptingValidator : AbstractValidator<TestCommandSettings>
+    {
+    }
+
+    private sealed class RejectingValidator : AbstractValidator<TestCommandSettings>
+    {
+        public RejectingValidator() => RuleFor(settings => settings.NotEmptyStringProperty).NotEmpty();
+    }
+}

--- a/tests/Spectre/CommandLine.Spectre.Serilog.Tests/GlobalUsings.cs
+++ b/tests/Spectre/CommandLine.Spectre.Serilog.Tests/GlobalUsings.cs
@@ -1,0 +1,2 @@
+// Global usings for Ploch.CommandLine.Spectre.Serilog.Tests
+global using FluentAssertions;

--- a/tests/Spectre/CommandLine.Spectre.Serilog.Tests/LoggerConfigurationExtensionsTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.Serilog.Tests/LoggerConfigurationExtensionsTests.cs
@@ -1,0 +1,128 @@
+using System.Diagnostics;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using Serilog;
+using Serilog.Events;
+
+namespace Ploch.CommandLine.Spectre.Serilog.Tests;
+
+/// <summary>
+///     Cover for the predefined Serilog configuration. The important behaviour is the split between the two files:
+///     the dedicated "errors" log must receive warnings and above only. The error sink previously sat outside its
+///     filtered sub-logger, which left the filter applying to nothing and the errors file receiving every event.
+/// </summary>
+public sealed class LoggerConfigurationExtensionsTests : IDisposable
+{
+    private readonly string _logDirectory = Path.Combine(Path.GetTempPath(), "ploch-commandline-serilog-tests", Guid.NewGuid().ToString("N"));
+
+    public LoggerConfigurationExtensionsTests() => Directory.CreateDirectory(_logDirectory);
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_logDirectory, recursive: true);
+        }
+        catch (IOException exception)
+        {
+            // A sink that has not released its handle yet must not fail the test; the directory is under TEMP.
+            Console.WriteLine($"Could not remove the temporary log directory: {exception.Message}");
+        }
+    }
+
+    [Fact]
+    public void ConfigureSerilog_should_write_every_level_to_the_main_log_file()
+    {
+        WriteSampleEvents("main-levels");
+
+        var mainLog = ReadLogFile("main-levels.log");
+
+        mainLog.Should().Contain("an informational message").And.Contain("a warning message").And.Contain("an error message");
+    }
+
+    [Fact]
+    public void ConfigureSerilog_should_send_only_warnings_and_above_to_the_errors_log_file()
+    {
+        WriteSampleEvents("filtered");
+
+        var errorLog = ReadLogFile("filtered-errors.log");
+
+        errorLog.Should()
+                .Contain("a warning message")
+                .And.Contain("an error message")
+                .And.Contain("a fatal message")
+                .And.NotContain("an informational message", "the errors file exists precisely to exclude routine events");
+    }
+
+    [Fact]
+    public void ConfigureSerilog_should_honour_the_minimum_level_taken_from_configuration()
+    {
+        var configuration = BuildConfiguration(("Serilog:MinimumLevel:Default", "Warning"));
+
+        WriteSampleEvents("minimum-level", configuration);
+
+        var mainLog = ReadLogFile("minimum-level.log");
+
+        mainLog.Should().NotContain("an informational message", "the configured minimum level suppresses it").And.Contain("a warning message");
+    }
+
+    [Fact]
+    public void ConfigureSerilog_should_default_to_information_when_configuration_gives_no_minimum_level()
+    {
+        WriteSampleEvents("default-level", BuildConfiguration());
+
+        var mainLog = ReadLogFile("default-level.log");
+
+        mainLog.Should().Contain("an informational message").And.NotContain("a debug message", "Information is the default floor");
+    }
+
+    [Fact]
+    public void ConfigureSerilog_should_apply_the_supplied_output_template_to_the_main_log_file()
+    {
+        WriteSampleEvents("templated", template: "CUSTOM|{Level:u3}|{Message:lj}{NewLine}");
+
+        var mainLog = ReadLogFile("templated.log");
+
+        mainLog.Should().Contain("CUSTOM|INF|an informational message", "the template replaces the default timestamped layout");
+    }
+
+    [Fact]
+    public void ConfigureSerilog_should_name_the_log_files_after_the_current_process_when_no_name_is_supplied()
+    {
+        using (var logger = new LoggerConfiguration().ConfigureSerilog(logPath: _logDirectory).CreateLogger())
+        {
+            logger.Information("an informational message");
+            logger.Error("an error message");
+        }
+
+        var processName = Process.GetCurrentProcess().ProcessName;
+        File.Exists(Path.Combine(_logDirectory, $"{processName}.log")).Should().BeTrue();
+        File.Exists(Path.Combine(_logDirectory, $"{processName}-errors.log")).Should().BeTrue();
+    }
+
+    private static IConfiguration BuildConfiguration(params (string Key, string Value)[] settings) =>
+        new ConfigurationBuilder().AddInMemoryCollection(settings.ToDictionary(setting => setting.Key, setting => (string?)setting.Value)).Build();
+
+    private void WriteSampleEvents(string logName, IConfiguration? configuration = null, string? template = null)
+    {
+        using var logger = new LoggerConfiguration().ConfigureSerilog(configuration, template, logName, _logDirectory).CreateLogger();
+
+        logger.Write(LogEventLevel.Debug, "a debug message");
+        logger.Write(LogEventLevel.Information, "an informational message");
+        logger.Write(LogEventLevel.Warning, "a warning message");
+        logger.Write(LogEventLevel.Error, "an error message");
+        logger.Write(LogEventLevel.Fatal, "a fatal message");
+    }
+
+    /// <summary>Reads a log file while the sink may still hold it open.</summary>
+    private string ReadLogFile(string fileName)
+    {
+        var path = Path.Combine(_logDirectory, fileName);
+        File.Exists(path).Should().BeTrue($"the configuration is expected to create {fileName}");
+
+        using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+
+        return reader.ReadToEnd();
+    }
+}

--- a/tests/Spectre/CommandLine.Spectre.Serilog.Tests/Ploch.CommandLine.Spectre.Serilog.Tests.csproj
+++ b/tests/Spectre/CommandLine.Spectre.Serilog.Tests/Ploch.CommandLine.Spectre.Serilog.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(TargetFrameworkVersion)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
+    <Platforms>AnyCPU;x64</Platforms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\ploch-common\src\TestingSupport.XUnit3.AutoMoq\Ploch.TestingSupport.XUnit3.AutoMoq.csproj" />
+    <ProjectReference Include="..\..\..\src\Spectre\CommandLine.Spectre.Serilog\Ploch.CommandLine.Spectre.Serilog.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Spectre/CommandLine.Spectre.Serilog.Tests/SerilogLoggingConfiguratorTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.Serilog.Tests/SerilogLoggingConfiguratorTests.cs
@@ -1,0 +1,79 @@
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Serilog;
+
+namespace Ploch.CommandLine.Spectre.Serilog.Tests;
+
+/// <summary>
+///     Cover for the DI entry point. <c>AddSerilog</c> used to configure Serilog twice — once through the bundle and
+///     once directly — and the second registration silently dropped the caller's output template.
+/// </summary>
+public sealed class SerilogLoggingConfiguratorTests : IDisposable
+{
+    private const string Template = "REGISTERED|{Level:u3}|{Message:lj}{NewLine}";
+
+    private readonly string _logDirectory = Path.Combine(Path.GetTempPath(), "ploch-commandline-serilog-tests", Guid.NewGuid().ToString("N"));
+
+    public SerilogLoggingConfiguratorTests() => Directory.CreateDirectory(_logDirectory);
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_logDirectory, recursive: true);
+        }
+        catch (IOException exception)
+        {
+            // A sink that has not released its handle yet must not fail the test; the directory is under TEMP.
+            Console.WriteLine($"Could not remove the temporary log directory: {exception.Message}");
+        }
+    }
+
+    [Fact]
+    public void AddSerilog_should_register_the_serilog_logger_exactly_once()
+    {
+        var services = new ServiceCollection();
+
+        services.AddSerilog(new ConfigurationBuilder().Build(), "registered", _logDirectory, Template);
+
+        services.Count(descriptor => descriptor.ServiceType == typeof(ILogger))
+                .Should()
+                .Be(1, "a second registration would build the logger again and discard the first configuration");
+    }
+
+    [Fact]
+    public void AddSerilog_should_return_the_same_service_collection_for_chaining()
+    {
+        var services = new ServiceCollection();
+
+        services.AddSerilog(new ConfigurationBuilder().Build(), "chained", _logDirectory).Should().BeSameAs(services);
+    }
+
+    [Fact]
+    public void AddSerilog_should_apply_the_supplied_template_and_log_name_to_the_resolved_logger()
+    {
+        var services = new ServiceCollection();
+        services.AddSerilog(new ConfigurationBuilder().Build(), "registered", _logDirectory, Template);
+
+        using (var provider = services.BuildServiceProvider())
+        {
+            var logger = provider.GetRequiredService<ILogger>();
+            logger.Information("a registered message");
+            (logger as IDisposable)?.Dispose();
+        }
+
+        ReadLogFile("registered.log").Should().Contain("REGISTERED|INF|a registered message", "the template the caller passed must survive registration");
+    }
+
+    private string ReadLogFile(string fileName)
+    {
+        var path = Path.Combine(_logDirectory, fileName);
+        File.Exists(path).Should().BeTrue($"the registration is expected to create {fileName}");
+
+        using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+
+        return reader.ReadToEnd();
+    }
+}

--- a/tests/Spectre/CommandLine.Spectre.Tests/AppBuilderTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/AppBuilderTests.cs
@@ -13,6 +13,11 @@ namespace Ploch.CommandLine.Spectre.Tests;
 ///     configuration each one records has to survive into the host that Spectre.Console.Cli resolves commands from —
 ///     which only happens once a command actually runs.
 /// </summary>
+/// <remarks>
+///     The three "keep only the last delegate" tests are characterisation tests: they pin the builder's current
+///     last-call-wins behaviour rather than endorsing it, so that changing it to compose the delegates (see issue
+///     #22) is a deliberate decision with a visible failure rather than a silent change.
+/// </remarks>
 [Collection(GlobalConsoleState.Name)]
 public sealed class AppBuilderTests : IDisposable
 {
@@ -195,11 +200,69 @@ public sealed class AppBuilderTests : IDisposable
         recorder.ConfigurationValue.Should().Be("from-command-line", "Host.CreateDefaultBuilder receives the arguments Create was given");
     }
 
+    [Fact]
+    public void ConfigureServices_should_keep_only_the_last_delegate_it_was_given()
+    {
+        var recorder = RunProbeCommand(builder =>
+                                       {
+                                           builder.ConfigureServices(services => services.AddSingleton(new Marker { Name = "first" }));
+                                           builder.ConfigureServices(services => services.AddSingleton(new Marker { Name = "second" }));
+                                       });
+
+        recorder.ExitCode.Should().Be(0);
+        recorder.MarkerNames.Should()
+                .ContainSingle("the builder stores one delegate, so the earlier registration never runs")
+                .Which.Should()
+                .Be("second");
+    }
+
+    [Fact]
+    public void ConfigureHost_should_keep_only_the_last_delegate_it_was_given()
+    {
+        var recorder = RunProbeCommand(builder =>
+                                       {
+                                           builder.ConfigureHost(host => host.ConfigureServices(services =>
+                                                                                                    services.AddSingleton(new Marker
+                                                                                                        { Name = "first" })));
+                                           builder.ConfigureHost(host => host.ConfigureServices(services =>
+                                                                                                    services.AddSingleton(new Marker
+                                                                                                        { Name = "second" })));
+                                       });
+
+        recorder.ExitCode.Should().Be(0);
+        recorder.MarkerNames.Should()
+                .ContainSingle("the builder stores one delegate, so the earlier registration never runs")
+                .Which.Should()
+                .Be("second");
+    }
+
+    [Fact]
+    public void ConfigureAppConfiguration_should_keep_only_the_last_delegate_it_was_given()
+    {
+        var recorder = RunProbeCommand(builder =>
+                                       {
+                                           builder.ConfigureAppConfiguration(configuration =>
+                                                                                 configuration.AddInMemoryCollection(new Dictionary<string, string?>
+                                                                                     {
+                                                                                         ["probe:key"] = "from-the-first-call"
+                                                                                     }));
+                                           builder.ConfigureAppConfiguration(configuration =>
+                                                                                 configuration.AddInMemoryCollection(new Dictionary<string, string?>
+                                                                                     {
+                                                                                         ["probe:other"] = "from-the-second-call"
+                                                                                     }));
+                                       });
+
+        recorder.ExitCode.Should().Be(0);
+        recorder.SecondConfigurationValue.Should().Be("from-the-second-call");
+        recorder.ConfigurationValue.Should().BeNull("the builder stores one delegate, so the earlier configuration source is never added");
+    }
+
     /// <summary>
     ///     Builds an application configured by <paramref name="configure" /> and runs a probe command through it.
     ///     The probe reports back through a static slot rather than a registered service, because
     ///     <see cref="AppBuilder.ConfigureServices(Action{IServiceCollection})" /> keeps only the last delegate it was
-    ///     given and the helper must not overwrite whatever the test itself configured.
+    ///     given (issue #22) and the helper must not overwrite whatever the test itself configured.
     /// </summary>
     private static ProbeRecorder RunProbeCommand(Action<AppBuilder> configure, CancellationTokenSource? cancellationTokenSource = null)
     {
@@ -227,7 +290,12 @@ public sealed class AppBuilderTests : IDisposable
 
         public Marker? Marker { get; set; }
 
+        /// <summary>Every marker the container holds, so a test can tell one registration from two.</summary>
+        public List<string> MarkerNames { get; } = [];
+
         public string? ConfigurationValue { get; set; }
+
+        public string? SecondConfigurationValue { get; set; }
 
         public CancellationTokenSource? CancellationTokenSource { get; set; }
     }
@@ -246,7 +314,9 @@ public sealed class AppBuilderTests : IDisposable
         {
             var recorder = Recorder ?? throw new InvalidOperationException("The probe recorder was not set before the run.");
             recorder.ConfigurationValue = configuration["probe:key"];
+            recorder.SecondConfigurationValue = configuration["probe:other"];
             recorder.CancellationTokenSource = cancellationTokenSource;
+            recorder.MarkerNames.AddRange(services.GetServices<Marker>().Select(marker => marker.Name));
             recorder.Marker = services.GetService<Marker>();
 
             return 0;

--- a/tests/Spectre/CommandLine.Spectre.Tests/AppBuilderTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/AppBuilderTests.cs
@@ -1,0 +1,260 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ploch.CommandLine.Spectre.Tests.Testing;
+using Ploch.Common.DependencyInjection;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Ploch.CommandLine.Spectre.Tests;
+
+/// <summary>
+///     Cover for the application builder. Every fluent method has to return the same builder so calls chain, and the
+///     configuration each one records has to survive into the host that Spectre.Console.Cli resolves commands from —
+///     which only happens once a command actually runs.
+/// </summary>
+[Collection(GlobalConsoleState.Name)]
+public sealed class AppBuilderTests : IDisposable
+{
+    private readonly IAnsiConsole _originalConsole = AnsiConsole.Console;
+    private readonly RecordingConsole _console = new();
+
+    public AppBuilderTests()
+    {
+        AnsiConsole.Console = _console.Console;
+        EnvironmentSettings.Current = new EnvironmentSettings(isDebugging: false, pauseBeforeExit: false, new Dictionary<string, string?>());
+    }
+
+    public void Dispose()
+    {
+        ProbeCommand.Recorder = null;
+        AnsiConsole.Console = _originalConsole;
+        EnvironmentSettings.Reset();
+        _console.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public void WithName_should_set_the_name_used_by_the_start_up_banner()
+    {
+        var appInfo = new ConsoleAppInfo();
+        var builder = new AppBuilder(appInfo, new CancellationTokenSource());
+
+        builder.WithName("Widget Tool").Should().BeSameAs(builder, "the fluent methods chain");
+
+        appInfo.Name.Should().Be("Widget Tool");
+    }
+
+    [Fact]
+    public void WithVersion_should_set_the_version_used_by_the_start_up_banner()
+    {
+        var appInfo = new ConsoleAppInfo();
+        var builder = new AppBuilder(appInfo, new CancellationTokenSource());
+
+        builder.WithVersion(new Version(1, 2, 3)).Should().BeSameAs(builder);
+
+        appInfo.Version.Should().Be(new Version(1, 2, 3));
+    }
+
+    [Fact]
+    public void WithDescription_should_set_the_description_used_by_the_start_up_banner()
+    {
+        var appInfo = new ConsoleAppInfo();
+        var builder = new AppBuilder(appInfo, new CancellationTokenSource());
+
+        builder.WithDescription("Does widget things").Should().BeSameAs(builder);
+
+        appInfo.Description.Should().Be("Does widget things");
+    }
+
+    [Fact]
+    public void ConfigureCommandApp_should_print_the_start_up_banner()
+    {
+        var recorder = RunProbeCommand(builder => builder.WithName("Widget Tool").WithVersion(new Version(4, 5)).WithDescription("Widget things"));
+
+        recorder.ExitCode.Should().Be(0);
+        _console.Output.Should().Contain("Widget Tool 4.5").And.Contain("Widget things");
+    }
+
+    [Fact]
+    public void ConfigureCommandApp_should_reject_an_application_without_a_name()
+    {
+        var builder = new AppBuilder(new ConsoleAppInfo(), new CancellationTokenSource());
+
+        var act = () => builder.ConfigureCommandApp(_ => { });
+
+        act.Should().Throw<InvalidOperationException>("the banner renders the name as FigletText, so it cannot be missing");
+    }
+
+    [Fact]
+    public void ConfigureServices_should_make_the_registered_services_available_to_a_command()
+    {
+        var marker = new Marker();
+
+        var recorder = RunProbeCommand(builder => builder.ConfigureServices(services => services.AddSingleton(marker)));
+
+        recorder.ExitCode.Should().Be(0);
+        recorder.Marker.Should().BeSameAs(marker);
+    }
+
+    [Fact]
+    public void ConfigureServices_should_expose_the_host_context_to_the_configurator()
+    {
+        HostBuilderContext? capturedContext = null;
+
+        var recorder = RunProbeCommand(builder => builder.ConfigureServices((context, services) =>
+                                                                            {
+                                                                                capturedContext = context;
+                                                                                services.AddSingleton(new Marker());
+                                                                            }));
+
+        recorder.ExitCode.Should().Be(0);
+        capturedContext.Should().NotBeNull();
+        capturedContext!.Configuration.Should().NotBeNull("the context carries the configuration built so far");
+    }
+
+    [Fact]
+    public void ConfigureAppConfiguration_should_make_the_added_configuration_visible_to_a_command()
+    {
+        var recorder = RunProbeCommand(builder =>
+                                           builder.ConfigureAppConfiguration(configuration =>
+                                                                                 configuration.AddInMemoryCollection(new Dictionary<string, string?>
+                                                                                     {
+                                                                                         ["probe:key"] = "from-configuration"
+                                                                                     })));
+
+        recorder.ExitCode.Should().Be(0);
+        recorder.ConfigurationValue.Should().Be("from-configuration");
+    }
+
+    [Fact]
+    public void ConfigureAppConfiguration_should_expose_the_host_context_to_the_configurator()
+    {
+        HostBuilderContext? capturedContext = null;
+
+        var recorder = RunProbeCommand(builder => builder.ConfigureAppConfiguration((context, configuration) =>
+                                                                                    {
+                                                                                        capturedContext = context;
+                                                                                        configuration.AddInMemoryCollection(
+                                                                                            new Dictionary<string, string?>
+                                                                                            {
+                                                                                                ["probe:key"] = "from-context"
+                                                                                            });
+                                                                                    }));
+
+        recorder.ExitCode.Should().Be(0);
+        capturedContext.Should().NotBeNull();
+        recorder.ConfigurationValue.Should().Be("from-context");
+    }
+
+    [Fact]
+    public void ConfigureHost_should_apply_the_delegate_to_the_host_builder()
+    {
+        var marker = new Marker();
+
+        var recorder = RunProbeCommand(builder =>
+                                           builder.ConfigureHost(hostBuilder =>
+                                                                     hostBuilder.ConfigureServices(services => services.AddSingleton(marker))));
+
+        recorder.ExitCode.Should().Be(0);
+        recorder.Marker.Should().BeSameAs(marker);
+    }
+
+    [Fact]
+    public void AddServicesBundle_should_register_the_services_the_bundle_configures()
+    {
+        var recorder = RunProbeCommand(builder => builder.AddServicesBundle<MarkerServicesBundle>());
+
+        recorder.ExitCode.Should().Be(0);
+        recorder.Marker.Should().NotBeNull("the bundle registers the marker in the container the command resolves from");
+    }
+
+    [Fact]
+    public void ConfigureCommandApp_should_register_the_cancellation_token_source_it_was_built_with()
+    {
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        var recorder = RunProbeCommand(_ => { }, cancellationTokenSource);
+
+        recorder.ExitCode.Should().Be(0);
+        recorder.CancellationTokenSource.Should().BeSameAs(cancellationTokenSource, "commands cancel the application through this source");
+    }
+
+    [Fact]
+    public void Create_should_feed_the_supplied_arguments_into_the_host_configuration()
+    {
+        var recorder = new ProbeRecorder();
+        ProbeCommand.Recorder = recorder;
+        var builder = AppBuilder.Create("--probe:key=from-command-line").WithName("Widget Tool");
+
+        var executor = builder.ConfigureCommandApp(configurator => configurator.AddCommand<ProbeCommand>("probe"));
+
+        recorder.ExitCode = executor.Run("probe");
+
+        recorder.ExitCode.Should().Be(0);
+        recorder.ConfigurationValue.Should().Be("from-command-line", "Host.CreateDefaultBuilder receives the arguments Create was given");
+    }
+
+    /// <summary>
+    ///     Builds an application configured by <paramref name="configure" /> and runs a probe command through it.
+    ///     The probe reports back through a static slot rather than a registered service, because
+    ///     <see cref="AppBuilder.ConfigureServices(Action{IServiceCollection})" /> keeps only the last delegate it was
+    ///     given and the helper must not overwrite whatever the test itself configured.
+    /// </summary>
+    private static ProbeRecorder RunProbeCommand(Action<AppBuilder> configure, CancellationTokenSource? cancellationTokenSource = null)
+    {
+        var recorder = new ProbeRecorder();
+        ProbeCommand.Recorder = recorder;
+        var builder = new AppBuilder(new ConsoleAppInfo { Name = "Probe App" }, cancellationTokenSource ?? new CancellationTokenSource());
+        configure(builder);
+
+        var executor = builder.ConfigureCommandApp(configurator => configurator.AddCommand<ProbeCommand>("probe"));
+
+        recorder.ExitCode = executor.Run("probe");
+
+        return recorder;
+    }
+
+    private sealed class Marker
+    {
+        public string Name { get; init; } = "marker";
+    }
+
+    /// <summary>Captures what the running command could see, so the builder's configuration can be asserted end to end.</summary>
+    private sealed class ProbeRecorder
+    {
+        public int ExitCode { get; set; } = int.MinValue;
+
+        public Marker? Marker { get; set; }
+
+        public string? ConfigurationValue { get; set; }
+
+        public CancellationTokenSource? CancellationTokenSource { get; set; }
+    }
+
+    private sealed class ProbeSettings : CommandSettings
+    {
+    }
+
+    private sealed class ProbeCommand(IConfiguration configuration, CancellationTokenSource cancellationTokenSource, IServiceProvider services)
+        : Command<ProbeSettings>
+    {
+        /// <summary>Set by the test before the run; safe because this class runs in a non-parallel collection.</summary>
+        public static ProbeRecorder? Recorder { get; set; }
+
+        public override int Execute(CommandContext context, ProbeSettings settings, CancellationToken cancellationToken)
+        {
+            var recorder = Recorder ?? throw new InvalidOperationException("The probe recorder was not set before the run.");
+            recorder.ConfigurationValue = configuration["probe:key"];
+            recorder.CancellationTokenSource = cancellationTokenSource;
+            recorder.Marker = services.GetService<Marker>();
+
+            return 0;
+        }
+    }
+
+    private sealed class MarkerServicesBundle : ServicesBundle
+    {
+        public override void DoConfigure() => Services.AddSingleton(new Marker());
+    }
+}

--- a/tests/Spectre/CommandLine.Spectre.Tests/CommandAppConfiguratorTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/CommandAppConfiguratorTests.cs
@@ -1,0 +1,52 @@
+using Moq;
+using Ploch.CommandLine.Spectre.Tests.Testing;
+using Spectre.Console.Cli;
+
+namespace Ploch.CommandLine.Spectre.Tests;
+
+/// <summary>
+///     Cover for the thin configurator that adapts <see cref="ICommandApp" /> to
+///     <see cref="ICommandAppConfigurator" />.
+/// </summary>
+[Collection(GlobalConsoleState.Name)]
+public sealed class CommandAppConfiguratorTests : IDisposable
+{
+    public void Dispose()
+    {
+        EnvironmentSettings.Reset();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public void Configure_should_forward_the_configuration_action_to_the_command_app()
+    {
+        var commandApp = new Mock<ICommandApp>();
+        Action<IConfigurator> configuration = _ => { };
+
+        new CommandAppConfigurator(commandApp.Object).Configure(configuration);
+
+        commandApp.Verify(app => app.Configure(configuration), Times.Once);
+    }
+
+    [Fact]
+    public void Configure_should_return_an_executor_bound_to_the_same_command_app()
+    {
+        var commandApp = new Mock<ICommandApp>();
+        commandApp.Setup(app => app.Run(It.IsAny<IEnumerable<string>>())).Returns(11);
+        EnvironmentSettings.Current = new EnvironmentSettings(isDebugging: false, pauseBeforeExit: false, new Dictionary<string, string?>());
+
+        var executor = new CommandAppConfigurator(commandApp.Object).Configure(_ => { });
+
+        executor.Run("anything").Should().Be(11, "the executor must run the command app that was configured");
+    }
+
+    [Fact]
+    public void Configure_should_reject_a_null_configuration_action()
+    {
+        var configurator = new CommandAppConfigurator(Mock.Of<ICommandApp>());
+
+        var act = () => configurator.Configure(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/tests/Spectre/CommandLine.Spectre.Tests/CommandAppExecutorTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/CommandAppExecutorTests.cs
@@ -1,0 +1,113 @@
+using Moq;
+using Ploch.CommandLine.Spectre.Tests.Testing;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Ploch.CommandLine.Spectre.Tests;
+
+/// <summary>
+///     Cover for the executor that wraps <see cref="ICommandApp" />. The pause-before-exit prompt used to be applied
+///     by <see cref="CommandAppExecutor.RunAsync" /> only, so the synchronous entry point silently ignored the setting.
+/// </summary>
+[Collection(GlobalConsoleState.Name)]
+public sealed class CommandAppExecutorTests : IDisposable
+{
+    private readonly TextReader _originalInput = Console.In;
+    private readonly IAnsiConsole _originalConsole = AnsiConsole.Console;
+
+    public void Dispose()
+    {
+        Console.SetIn(_originalInput);
+        AnsiConsole.Console = _originalConsole;
+        EnvironmentSettings.Reset();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public void Run_should_return_the_exit_code_produced_by_the_command_app()
+    {
+        var commandApp = new Mock<ICommandApp>();
+        commandApp.Setup(app => app.Run(It.IsAny<IEnumerable<string>>())).Returns(7);
+        SetPauseBeforeExit(false);
+        string[] expectedArguments = ["build", "--verbose"];
+
+        new CommandAppExecutor(commandApp.Object).Run("build", "--verbose").Should().Be(7);
+
+        commandApp.Verify(app => app.Run(It.Is<IEnumerable<string>>(args => args.SequenceEqual(expectedArguments))), Times.Once);
+    }
+
+    [Fact]
+    public async Task RunAsync_should_return_the_exit_code_produced_by_the_command_app()
+    {
+        var commandApp = new Mock<ICommandApp>();
+        commandApp.Setup(app => app.RunAsync(It.IsAny<IEnumerable<string>>())).ReturnsAsync(3);
+        SetPauseBeforeExit(false);
+
+        var result = await new CommandAppExecutor(commandApp.Object).RunAsync("build");
+
+        result.Should().Be(3);
+    }
+
+    [Fact]
+    public void Run_should_not_prompt_when_pausing_before_exit_is_disabled()
+    {
+        using var console = UseRecordingConsole();
+        SetPauseBeforeExit(false);
+
+        new CommandAppExecutor(Mock.Of<ICommandApp>()).Run("build");
+
+        console.Output.Should().BeEmpty("an ordinary invocation must not appear to hang waiting for Enter");
+    }
+
+    [Fact]
+    public void Run_should_prompt_and_wait_for_input_when_pausing_before_exit_is_enabled()
+    {
+        using var console = UseRecordingConsole();
+        SetPauseBeforeExit(true);
+        var input = new TrackingReader();
+        Console.SetIn(input);
+
+        new CommandAppExecutor(Mock.Of<ICommandApp>()).Run("build");
+
+        console.Output.Should().Contain("Press Enter to exit...");
+        input.ReadLineCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task RunAsync_should_prompt_and_wait_for_input_when_pausing_before_exit_is_enabled()
+    {
+        using var console = UseRecordingConsole();
+        SetPauseBeforeExit(true);
+        var input = new TrackingReader();
+        Console.SetIn(input);
+
+        await new CommandAppExecutor(Mock.Of<ICommandApp>()).RunAsync("build");
+
+        console.Output.Should().Contain("Press Enter to exit...");
+        input.ReadLineCount.Should().Be(1, "Run and RunAsync must honour the setting identically");
+    }
+
+    private static void SetPauseBeforeExit(bool pauseBeforeExit) =>
+        EnvironmentSettings.Current = new EnvironmentSettings(isDebugging: false, pauseBeforeExit, new Dictionary<string, string?>());
+
+    private static RecordingConsole UseRecordingConsole()
+    {
+        var console = new RecordingConsole();
+        AnsiConsole.Console = console.Console;
+
+        return console;
+    }
+
+    /// <summary>A stdin stand-in that returns end-of-input immediately and records that it was consulted.</summary>
+    private sealed class TrackingReader : TextReader
+    {
+        public int ReadLineCount { get; private set; }
+
+        public override string? ReadLine()
+        {
+            ReadLineCount++;
+
+            return null;
+        }
+    }
+}

--- a/tests/Spectre/CommandLine.Spectre.Tests/Commands/AsyncAppCommandTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/Commands/AsyncAppCommandTests.cs
@@ -90,10 +90,23 @@ public class AsyncAppCommandTests
         result.Should().Be((int)ExitCode.Error);
     }
 
+    [Theory]
+    [AutoMockData]
+    public void Validate_should_return_the_result_produced_by_the_configured_validator(CommandContext context)
+    {
+        var command = CreateCommand((_, _) => Task.FromResult(ExitCode.Success), validator: new RejectingValidator());
+
+        var result = command.Validate(context, new StubSettings());
+
+        result.Successful.Should().BeFalse();
+        result.Message.Should().Be("settings rejected");
+    }
+
     private static StubAsyncCommand CreateCommand(Func<StubSettings, CancellationToken, Task<ExitCode>> body,
                                                   IExceptionHandler? exceptionHandler = null,
-                                                  CommandArgumentsRootProcessor? processor = null) =>
-        new(processor ?? new([]), new PassThroughValidator(), exceptionHandler ?? new RecordingExceptionHandler(), new NullOutput(), body);
+                                                  CommandArgumentsRootProcessor? processor = null,
+                                                  ICommandSettingsValidator<StubSettings>? validator = null) =>
+        new(processor ?? new([]), validator ?? new PassThroughValidator(), exceptionHandler ?? new RecordingExceptionHandler(), new NullOutput(), body);
 
     private sealed class StubSettings : CommandSettings
     {
@@ -102,6 +115,11 @@ public class AsyncAppCommandTests
     private sealed class PassThroughValidator : ICommandSettingsValidator<StubSettings>
     {
         public ValidationResult Validate(CommandContext context, StubSettings settings) => ValidationResult.Success();
+    }
+
+    private sealed class RejectingValidator : ICommandSettingsValidator<StubSettings>
+    {
+        public ValidationResult Validate(CommandContext context, StubSettings settings) => ValidationResult.Error("settings rejected");
     }
 
     private sealed class RecordingExceptionHandler : IExceptionHandler

--- a/tests/Spectre/CommandLine.Spectre.Tests/Commands/CommandSettingsValidatorTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/Commands/CommandSettingsValidatorTests.cs
@@ -1,0 +1,62 @@
+using Ploch.CommandLine.Spectre.Commands;
+using Ploch.TestingSupport.XUnit3.AutoMoq;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Ploch.CommandLine.Spectre.Tests.Commands;
+
+/// <summary>
+///     Cover for the default settings validator, which delegates to <see cref="CommandSettings.Validate" /> after
+///     guarding its arguments.
+/// </summary>
+public class CommandSettingsValidatorTests
+{
+    [Theory]
+    [AutoMockData]
+    public void Validate_should_return_the_result_produced_by_the_settings(CommandContext context)
+    {
+        var validator = new CommandSettingsValidator<StubSettings>();
+
+        var result = validator.Validate(context, new StubSettings { Result = ValidationResult.Error("not allowed") });
+
+        result.Successful.Should().BeFalse();
+        result.Message.Should().Be("not allowed");
+    }
+
+    [Theory]
+    [AutoMockData]
+    public void Validate_should_return_success_when_the_settings_are_valid(CommandContext context)
+    {
+        var validator = new CommandSettingsValidator<StubSettings>();
+
+        validator.Validate(context, new StubSettings()).Successful.Should().BeTrue();
+    }
+
+    [Theory]
+    [AutoMockData]
+    public void Validate_should_reject_null_settings(CommandContext context)
+    {
+        var validator = new CommandSettingsValidator<StubSettings>();
+
+        var act = () => validator.Validate(context, null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Validate_should_reject_a_null_context()
+    {
+        var validator = new CommandSettingsValidator<StubSettings>();
+
+        var act = () => validator.Validate(null!, new StubSettings());
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    private sealed class StubSettings : CommandSettings
+    {
+        public ValidationResult Result { get; init; } = ValidationResult.Success();
+
+        public override ValidationResult Validate() => Result;
+    }
+}

--- a/tests/Spectre/CommandLine.Spectre.Tests/Commands/DefaultExceptionHandlerTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/Commands/DefaultExceptionHandlerTests.cs
@@ -1,0 +1,83 @@
+using System.ComponentModel;
+using Ploch.CommandLine.Spectre.Commands;
+using Ploch.CommandLine.Spectre.Output;
+using Ploch.CommandLine.Spectre.Tests.Testing;
+
+namespace Ploch.CommandLine.Spectre.Tests.Commands;
+
+/// <summary>
+///     Cover for the default exception handler. A <see cref="Win32Exception" /> is deliberately routed around the
+///     markup pipeline: its text contains '[' sequences that Spectre would parse as markup and throw on, inside
+///     the handler that is supposed to be reporting the original failure.
+/// </summary>
+public class DefaultExceptionHandlerTests
+{
+    [Fact]
+    public void HandleException_should_return_the_error_exit_code()
+    {
+        using var console = new RecordingConsole();
+        var handler = new DefaultExceptionHandler(console.Console, new AnsiConsoleMarkupOutput(console.Console, new MessageFormatterProcessor([], [])));
+
+        handler.HandleException(new InvalidOperationException("boom")).Should().Be((int)ExitCode.Error);
+    }
+
+    [Fact]
+    public void HandleException_should_render_an_ordinary_exception_through_the_output()
+    {
+        using var console = new RecordingConsole();
+        var output = new RecordingOutput();
+        var handler = new DefaultExceptionHandler(console.Console, output);
+
+        var exception = new InvalidOperationException("ordinary failure");
+        handler.HandleException(exception);
+
+        output.Exceptions.Should().ContainSingle().Which.Should().BeSameAs(exception);
+        console.Output.Should().BeEmpty("an ordinary exception goes through the markup-aware output, not straight to the console");
+    }
+
+    [Fact]
+    public void HandleException_should_bypass_the_markup_output_for_a_Win32_exception()
+    {
+        using var console = new RecordingConsole();
+        var output = new RecordingOutput();
+        var handler = new DefaultExceptionHandler(console.Console, output);
+
+        handler.HandleException(new Win32Exception(5));
+
+        output.Exceptions.Should().BeEmpty("a Win32 exception must not reach the markup parser");
+        console.Output.Should().Contain(nameof(Win32Exception));
+    }
+
+    [Fact]
+    public void HandleException_should_bypass_the_markup_output_when_a_Win32_exception_is_the_inner_exception()
+    {
+        using var console = new RecordingConsole();
+        var output = new RecordingOutput();
+        var handler = new DefaultExceptionHandler(console.Console, output);
+
+        handler.HandleException(new InvalidOperationException("wrapper", new Win32Exception(5)));
+
+        output.Exceptions.Should().BeEmpty("the unsafe text is still present when the Win32 exception is nested");
+        console.Output.Should().Contain(nameof(Win32Exception));
+    }
+
+    [Fact]
+    public void HandleException_should_write_a_Win32_exception_without_markup_parsing_failing()
+    {
+        using var console = new RecordingConsole();
+        var handler = new DefaultExceptionHandler(console.Console, new AnsiConsoleMarkupOutput(console.Console, new MessageFormatterProcessor([], [])));
+
+        var act = () => handler.HandleException(new Win32Exception(5, "text with [square] brackets"));
+
+        act.Should().NotThrow("the handler must not throw on the content it is reporting");
+        console.Output.Should().Contain("[square]");
+    }
+
+    /// <summary>Records the exceptions passed to the output so the routing decision can be asserted.</summary>
+    private sealed class RecordingOutput : NoOpOutput
+    {
+        public List<Exception?> Exceptions { get; } = [];
+
+        protected override void OnException(Exception? exception) => Exceptions.Add(exception);
+    }
+}

--- a/tests/Spectre/CommandLine.Spectre.Tests/ConsoleAppInfoBannerTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/ConsoleAppInfoBannerTests.cs
@@ -1,0 +1,115 @@
+using Ploch.CommandLine.Spectre.Tests.Testing;
+using Spectre.Console;
+
+namespace Ploch.CommandLine.Spectre.Tests;
+
+/// <summary>
+///     Cover for <see cref="ConsoleAppInfoExtensions.PrintAppInfo" />, the start-up banner. It renders the name as
+///     FigletText exactly once — a second render was the visible symptom of the duplicated-banner defect — then the
+///     name/version line and, only when there is one, the description.
+/// </summary>
+[Collection(GlobalConsoleState.Name)]
+public sealed class ConsoleAppInfoBannerTests : IDisposable
+{
+    private readonly IAnsiConsole _originalConsole = AnsiConsole.Console;
+
+    public void Dispose()
+    {
+        AnsiConsole.Console = _originalConsole;
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public void PrintAppInfo_should_render_the_name_line_and_the_figlet_banner()
+    {
+        using var console = UseRecordingConsole();
+
+        new ConsoleAppInfo { Name = "Widget" }.PrintAppInfo();
+
+        RenderedLines(console).Should().Contain("Widget", "the plain name line follows the banner");
+        RenderedLines(console).Should().HaveCountGreaterThan(3, "the FigletText banner spans several lines above the name line");
+    }
+
+    [Fact]
+    public void PrintAppInfo_should_append_the_version_to_the_name_line()
+    {
+        using var console = UseRecordingConsole();
+
+        new ConsoleAppInfo { Name = "Widget", Version = new Version(2, 4, 6) }.PrintAppInfo();
+
+        RenderedLines(console).Should().Contain("Widget 2.4.6");
+    }
+
+    [Fact]
+    public void PrintAppInfo_should_omit_the_version_when_none_is_set()
+    {
+        using var console = UseRecordingConsole();
+
+        new ConsoleAppInfo { Name = "Widget" }.PrintAppInfo();
+
+        RenderedLines(console)
+            .Should()
+            .NotContain(line => line.StartsWith("Widget ", StringComparison.Ordinal), "with no version there is nothing to append to the name");
+    }
+
+    [Fact]
+    public void PrintAppInfo_should_render_the_description_when_one_is_set()
+    {
+        using var console = UseRecordingConsole();
+
+        new ConsoleAppInfo { Name = "Widget", Description = "Makes widgets." }.PrintAppInfo();
+
+        RenderedLines(console).Should().Contain("Makes widgets.");
+    }
+
+    [Fact]
+    public void PrintAppInfo_should_omit_the_description_line_when_there_is_no_description()
+    {
+        using var withDescription = new RecordingConsole();
+        using var withoutDescription = new RecordingConsole();
+
+        AnsiConsole.Console = withDescription.Console;
+        new ConsoleAppInfo { Name = "Widget", Description = "Makes widgets." }.PrintAppInfo();
+
+        AnsiConsole.Console = withoutDescription.Console;
+        new ConsoleAppInfo { Name = "Widget", Description = string.Empty }.PrintAppInfo();
+
+        RenderedLines(withoutDescription)
+            .Should()
+            .HaveCount(RenderedLines(withDescription).Count - 1, "the description line is the only difference between the two banners");
+    }
+
+    [Fact]
+    public void PrintAppInfo_should_render_the_name_only_once_below_the_banner()
+    {
+        using var console = UseRecordingConsole();
+
+        new ConsoleAppInfo { Name = "Widget", Description = "Makes widgets." }.PrintAppInfo();
+
+        RenderedLines(console).Count(line => line == "Widget").Should().Be(1, "the banner is drawn once, so exactly one plain name line follows it");
+    }
+
+    [Fact]
+    public void PrintAppInfo_should_reject_an_application_without_a_name()
+    {
+        using var console = UseRecordingConsole();
+        var appInfo = new ConsoleAppInfo { Name = "  " };
+
+        Action act = appInfo.PrintAppInfo;
+
+        act.Should().Throw<InvalidOperationException>();
+        console.Output.Should().BeEmpty("validation runs before anything is rendered");
+    }
+
+    /// <summary>Splits the captured output into trimmed, non-blank lines so assertions ignore Spectre's padding.</summary>
+    private static List<string> RenderedLines(RecordingConsole console) =>
+        console.Output.Split(Environment.NewLine).Select(line => line.TrimEnd()).Where(line => line.Length > 0).ToList();
+
+    private static RecordingConsole UseRecordingConsole()
+    {
+        var console = new RecordingConsole();
+        AnsiConsole.Console = console.Console;
+
+        return console;
+    }
+}

--- a/tests/Spectre/CommandLine.Spectre.Tests/DependencyInjection/DependencyInjectionTypeRegistrarTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/DependencyInjection/DependencyInjectionTypeRegistrarTests.cs
@@ -1,0 +1,128 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ploch.CommandLine.Spectre.DependencyInjection;
+
+namespace Ploch.CommandLine.Spectre.Tests.DependencyInjection;
+
+/// <summary>
+///     Cover for the bridge between Spectre.Console.Cli's type registry and Microsoft.Extensions.DependencyInjection.
+///     Every registration made here has to be visible from the resolver the registrar builds.
+/// </summary>
+public class DependencyInjectionTypeRegistrarTests
+{
+    [Fact]
+    public void Register_should_make_the_implementation_resolvable_through_the_built_resolver()
+    {
+        var registrar = new DependencyInjectionTypeRegistrar(CreateHostBuilder());
+        registrar.Register(typeof(ServiceContract), typeof(Service));
+
+        using var resolver = (DependencyInjectionTypeResolver)registrar.Build();
+
+        var resolved = resolver.Resolve(typeof(ServiceContract)).Should().BeAssignableTo<ServiceContract>().Subject;
+        resolved.Describe().Should().Be(nameof(Service), "the registered implementation is what the resolver hands back");
+    }
+
+    [Fact]
+    public void RegisterInstance_should_return_the_very_same_instance()
+    {
+        var instance = new Service();
+        var registrar = new DependencyInjectionTypeRegistrar(CreateHostBuilder());
+        registrar.RegisterInstance(typeof(ServiceContract), instance);
+
+        using var resolver = (DependencyInjectionTypeResolver)registrar.Build();
+
+        resolver.Resolve(typeof(ServiceContract)).Should().BeSameAs(instance);
+    }
+
+    [Fact]
+    public void RegisterLazy_should_defer_the_factory_until_the_service_is_resolved()
+    {
+        var invocations = 0;
+        var registrar = new DependencyInjectionTypeRegistrar(CreateHostBuilder());
+        registrar.RegisterLazy(typeof(ServiceContract),
+                               () =>
+                               {
+                                   invocations++;
+
+                                   return new Service();
+                               });
+
+        using var resolver = (DependencyInjectionTypeResolver)registrar.Build();
+        invocations.Should().Be(0, "building the resolver must not instantiate the service");
+
+        resolver.Resolve(typeof(ServiceContract)).Should().BeOfType<Service>();
+        invocations.Should().Be(1);
+    }
+
+    [Fact]
+    public void RegisterLazy_should_reject_a_null_factory()
+    {
+        var registrar = new DependencyInjectionTypeRegistrar(CreateHostBuilder());
+
+        var act = () => registrar.RegisterLazy(typeof(ServiceContract), null);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    private static HostBuilder CreateHostBuilder() => new();
+
+    private class ServiceContract
+    {
+        public virtual string Describe() => nameof(ServiceContract);
+    }
+
+    private sealed class Service : ServiceContract
+    {
+        public override string Describe() => nameof(Service);
+    }
+}
+
+/// <summary>
+///     Cover for the resolver, whose contract is to answer <see langword="null" /> rather than throw for anything
+///     it cannot supply, and to own the lifetime of the host it was given.
+/// </summary>
+public class DependencyInjectionTypeResolverTests
+{
+    [Fact]
+    public void Resolve_should_return_null_for_a_null_type()
+    {
+        using var resolver = new DependencyInjectionTypeResolver(new HostBuilder().Build());
+
+        resolver.Resolve(null).Should().BeNull();
+    }
+
+    [Fact]
+    public void Resolve_should_return_null_for_an_unregistered_type()
+    {
+        using var resolver = new DependencyInjectionTypeResolver(new HostBuilder().Build());
+
+        resolver.Resolve(typeof(DependencyInjectionTypeResolverTests)).Should().BeNull();
+    }
+
+    [Fact]
+    public void Constructor_should_reject_a_null_host()
+    {
+        var act = () => new DependencyInjectionTypeResolver(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Dispose_should_dispose_the_underlying_host()
+    {
+        var host = new HostBuilder().ConfigureServices(services => services.AddSingleton<TrackingDisposable>()).Build();
+        var resolver = new DependencyInjectionTypeResolver(host);
+        var disposable = resolver.Resolve(typeof(TrackingDisposable)).Should().BeOfType<TrackingDisposable>().Subject;
+
+        resolver.Dispose();
+
+        disposable.IsDisposed.Should().BeTrue("the resolver owns the host and must release the services it created");
+    }
+
+    private sealed class TrackingDisposable : IDisposable
+    {
+        public bool IsDisposed { get; private set; }
+
+        public void Dispose() => IsDisposed = true;
+    }
+}

--- a/tests/Spectre/CommandLine.Spectre.Tests/Output/AnsiConsoleMarkupOutputTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/Output/AnsiConsoleMarkupOutputTests.cs
@@ -1,0 +1,320 @@
+using System.Globalization;
+using Ploch.CommandLine.Spectre.Output;
+using Ploch.CommandLine.Spectre.Tests.Testing;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+
+namespace Ploch.CommandLine.Spectre.Tests.Output;
+
+/// <summary>
+///     Cover for the console output adapter. The dispatch inside <see cref="AnsiConsoleMarkupOutput.Write{TMessage}" />
+///     is the path that previously wrote writer-handled messages twice, and the bold/error helpers are the only
+///     place the markup tags reach the formatter processor.
+/// </summary>
+public class AnsiConsoleMarkupOutputTests
+{
+    [Fact]
+    public void Write_should_render_a_plain_string_as_markup()
+    {
+        using var console = new RecordingConsole();
+        var output = CreateOutput(console);
+
+        output.Write("[bold]emphasised[/]");
+
+        console.Output.Should().Be("emphasised", "the markup tags are interpreted, not printed literally");
+    }
+
+    [Fact]
+    public void Write_should_render_an_interpolated_string_with_its_arguments_escaped()
+    {
+        using var console = new RecordingConsole();
+        var output = CreateOutput(console);
+
+        output.Write<FormattableString>($"value is {"[not-markup]"}");
+
+        console.Output.Should().Be("value is [not-markup]", "interpolated arguments are escaped rather than parsed as markup");
+    }
+
+    [Fact]
+    public void Write_should_use_the_supplied_format_provider_for_an_interpolated_string()
+    {
+        using var console = new RecordingConsole();
+        var output = CreateOutput(console);
+
+        output.Write<FormattableString>($"{1234.5:N2}", CultureInfo.GetCultureInfo("de-DE"));
+
+        console.Output.Should().Be("1.234,50", "the German culture groups with '.' and separates decimals with ','");
+    }
+
+    [Fact]
+    public void Write_should_render_a_renderable_through_the_console()
+    {
+        using var console = new RecordingConsole();
+        var output = CreateOutput(console);
+
+        output.Write<IRenderable>(new Text("renderable text"));
+
+        console.Output.Should().Contain("renderable text");
+    }
+
+    [Fact]
+    public void Write_should_render_a_renderable_passed_to_the_dedicated_overload()
+    {
+        using var console = new RecordingConsole();
+        var output = CreateOutput(console);
+
+        IRenderable renderable = new Text("dedicated overload");
+
+        var chained = output.Write(renderable);
+
+        console.Output.Should().Contain("dedicated overload");
+        chained.Should().BeSameAs(output);
+    }
+
+    [Fact]
+    public void Write_should_delegate_to_a_registered_writer_exactly_once()
+    {
+        using var console = new RecordingConsole();
+        var writer = new CountingEnumerableWriter();
+        var output = new AnsiConsoleMarkupOutput(console.Console, new MessageFormatterProcessor([], [writer]));
+
+        int[] items = [1, 2, 3];
+
+        output.Write(items);
+
+        writer.WriteCount.Should().Be(1);
+        console.Output.Should().BeEmpty("a message a writer handled must not also be written by the fallback path");
+    }
+
+    [Fact]
+    public void Write_should_fall_back_to_ToString_when_no_writer_handles_the_message()
+    {
+        using var console = new RecordingConsole();
+        var output = new AnsiConsoleMarkupOutput(console.Console, new MessageFormatterProcessor([], []));
+
+        output.Write(new UnhandledMessage());
+
+        console.Output.Should().Be(UnhandledMessage.Text);
+    }
+
+    [Fact]
+    public void Write_should_render_nothing_for_a_null_message()
+    {
+        using var console = new RecordingConsole();
+        var output = new AnsiConsoleMarkupOutput(console.Console, new MessageFormatterProcessor([], []));
+
+        output.Write<UnhandledMessage?>(null);
+
+        console.Output.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void WriteLine_should_terminate_the_line_after_a_string()
+    {
+        using var console = new RecordingConsole();
+        var output = CreateOutput(console);
+
+        output.WriteLine("line");
+
+        console.Output.Should().Be("line" + Environment.NewLine);
+    }
+
+    [Fact]
+    public void WriteLine_should_terminate_the_line_after_an_interpolated_string()
+    {
+        using var console = new RecordingConsole();
+        var output = CreateOutput(console);
+
+        output.WriteLine<FormattableString>($"count: {7}");
+
+        console.Output.Should().Be("count: 7" + Environment.NewLine);
+    }
+
+    [Fact]
+    public void WriteLine_should_render_a_non_string_message_via_ToString()
+    {
+        using var console = new RecordingConsole();
+        var output = CreateOutput(console);
+
+        output.WriteLine(new UnhandledMessage());
+
+        console.Output.Should().Be(UnhandledMessage.Text + Environment.NewLine);
+    }
+
+    [Fact]
+    public void WriteLine_should_write_only_a_line_terminator_for_a_null_message()
+    {
+        using var console = new RecordingConsole();
+        var output = CreateOutput(console);
+
+        output.WriteLine<UnhandledMessage?>(null);
+
+        console.Output.Should().Be(Environment.NewLine);
+    }
+
+    [Fact]
+    public void WriteLine_should_write_only_a_line_terminator_when_called_without_a_message()
+    {
+        using var console = new RecordingConsole();
+        var output = CreateOutput(console);
+
+        output.WriteLine();
+
+        console.Output.Should().Be(Environment.NewLine);
+    }
+
+    [Fact]
+    public void EndLine_should_write_a_line_terminator()
+    {
+        using var console = new RecordingConsole();
+        var output = CreateOutput(console);
+
+        output.EndLine();
+
+        console.Output.Should().Be(Environment.NewLine);
+    }
+
+    [Fact]
+    public void MarkupInterpolated_should_escape_the_interpolated_arguments()
+    {
+        using var console = new RecordingConsole();
+        var output = CreateOutput(console);
+
+        output.MarkupInterpolated($"[bold]{"[literal]"}[/]");
+
+        console.Output.Should().Be("[literal]");
+    }
+
+    [Fact]
+    public void MarkupLineInterpolated_should_escape_the_arguments_and_terminate_the_line()
+    {
+        using var console = new RecordingConsole();
+        var output = CreateOutput(console);
+
+        output.MarkupLineInterpolated($"[bold]{"[literal]"}[/]");
+
+        console.Output.Should().Be("[literal]" + Environment.NewLine);
+    }
+
+    [Fact]
+    public void WriteBold_and_WriteBoldLine_should_ask_the_processor_for_the_bold_markup_tag()
+    {
+        using var console = new RecordingConsole();
+        var processor = new RecordingFormatterProcessor();
+        var output = new AnsiConsoleMarkupOutput(console.Console, processor);
+
+        output.WriteBold("message");
+        output.WriteBoldLine("message");
+
+        processor.RequestedTags.Should().Equal("bold", "bold");
+    }
+
+    [Fact]
+    public void WriteError_and_WriteErrorLine_should_ask_the_processor_for_the_red_markup_tag()
+    {
+        using var console = new RecordingConsole();
+        var processor = new RecordingFormatterProcessor();
+        var output = new AnsiConsoleMarkupOutput(console.Console, processor);
+
+        output.WriteError("message");
+        output.WriteErrorLine("message");
+
+        processor.RequestedTags.Should().Equal("red", "red");
+    }
+
+    [Fact]
+    public void WriteErrorLine_should_render_the_message_and_terminate_the_line()
+    {
+        using var console = new RecordingConsole();
+        var output = CreateOutput(console);
+
+        output.WriteErrorLine("it failed");
+
+        console.Output.Should().Be("it failed" + Environment.NewLine, "the red markup is consumed by the renderer, so only the text survives");
+    }
+
+    [Fact]
+    public void WriteBold_should_render_the_message_without_a_line_terminator()
+    {
+        using var console = new RecordingConsole();
+        var output = CreateOutput(console);
+
+        output.WriteBold("strong");
+
+        console.Output.Should().Be("strong");
+    }
+
+    [Fact]
+    public void WriteException_should_render_the_exception_message()
+    {
+        using var console = new RecordingConsole();
+        var output = CreateOutput(console);
+
+        output.WriteException(new InvalidOperationException("the failure detail"));
+
+        console.Output.Should().Contain("the failure detail");
+    }
+
+    [Fact]
+    public void WriteException_should_write_nothing_for_a_null_exception()
+    {
+        using var console = new RecordingConsole();
+        var output = CreateOutput(console);
+
+        output.WriteException<Exception>(null);
+
+        console.Output.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Write_should_return_the_same_instance_so_calls_can_be_chained()
+    {
+        using var console = new RecordingConsole();
+        var output = CreateOutput(console);
+
+        var chained = output.Write("a").WriteLine("b").WriteBold("c").WriteError("d").EndLine();
+
+        chained.Should().BeSameAs(output);
+        console.Output.Should().Be("ab" + Environment.NewLine + "cd" + Environment.NewLine);
+    }
+
+    private static AnsiConsoleMarkupOutput CreateOutput(RecordingConsole console) =>
+        new(console.Console, new MessageFormatterProcessor([new StringMessageFormatter()], []));
+
+    private sealed class UnhandledMessage
+    {
+        public const string Text = "unhandled-message";
+
+        public override string ToString() => Text;
+    }
+
+    /// <summary>Counts how many times the writer was invoked, which is what the double-write regression turns on.</summary>
+    private sealed class CountingEnumerableWriter : TypeMessageWriter<System.Collections.IEnumerable>
+    {
+        public int WriteCount { get; private set; }
+
+        public override void Write(System.Collections.IEnumerable? message, IMessageFormatterProcessor? formatterProcessor = null) => WriteCount++;
+    }
+
+    /// <summary>Records the markup tags the output adapter asks for, which is otherwise invisible once rendered.</summary>
+    private sealed class RecordingFormatterProcessor : IMessageFormatterProcessor
+    {
+        public List<string?> RequestedTags { get; } = [];
+
+        public FormattableString GetMessageText(FormattableString? message, string? markupTag = null)
+        {
+            RequestedTags.Add(markupTag);
+
+            return message ?? $"";
+        }
+
+        public string? GetMessageText<TMessage>(TMessage? message, string? markupTag = null)
+        {
+            RequestedTags.Add(markupTag);
+
+            return message?.ToString();
+        }
+
+        public bool WriteMessage<TMessage>(TMessage message) => false;
+    }
+}

--- a/tests/Spectre/CommandLine.Spectre.Tests/Output/EnumerableMessageFormatterTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/Output/EnumerableMessageFormatterTests.cs
@@ -1,0 +1,74 @@
+using System.Collections;
+using Ploch.CommandLine.Spectre.Output;
+using Spectre.Console;
+
+namespace Ploch.CommandLine.Spectre.Tests.Output;
+
+/// <summary>
+///     Cover for the formatter that renders a collection as a bulleted block.
+/// </summary>
+public class EnumerableMessageFormatterTests
+{
+    [Fact]
+    public void GetMessage_should_return_an_empty_string_for_a_null_collection()
+    {
+        new EnumerableMessageFormatter().GetMessage(null).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GetMessage_should_return_an_empty_string_for_an_empty_collection()
+    {
+        new EnumerableMessageFormatter().GetMessage(Array.Empty<string>()).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GetMessage_should_render_one_bulleted_line_per_item()
+    {
+        var formatter = new EnumerableMessageFormatter();
+        string[] items = ["first", "second"];
+
+        var result = formatter.GetMessage(items, new MessageFormatterProcessor([], []));
+
+        var lines = result.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        lines.Should().HaveCount(2);
+        lines[0].Should().Be($"{Emoji.Known.BackhandIndexPointingRight} first");
+        lines[1].Should().Be($"{Emoji.Known.BackhandIndexPointingRight} second");
+    }
+
+    [Fact]
+    public void GetMessage_should_route_each_item_through_the_supplied_formatter_processor()
+    {
+        var formatter = new EnumerableMessageFormatter();
+        var processor = new MessageFormatterProcessor([new BracketingFormatter()], []);
+        string[] items = ["item"];
+
+        var result = formatter.GetMessage(items, processor);
+
+        result.Should().Contain("<item>", "the processor formats every item rather than the collection being flattened with ToString");
+    }
+
+    [Fact]
+    public void GetMessage_should_render_empty_item_text_when_no_formatter_processor_is_supplied()
+    {
+        string[] items = ["item"];
+
+        var result = new EnumerableMessageFormatter().GetMessage(items);
+
+        result.Trim().Should().Be(Emoji.Known.BackhandIndexPointingRight, "without a processor there is nothing to turn the item into text");
+    }
+
+    [Fact]
+    public void CanHandle_should_accept_collections_and_reject_scalars()
+    {
+        var formatter = new EnumerableMessageFormatter();
+
+        formatter.CanHandle(new List<int>()).Should().BeTrue();
+        formatter.CanHandle(42).Should().BeFalse();
+        formatter.MessageType.Should().Be<IEnumerable>();
+    }
+
+    private sealed class BracketingFormatter : TypeMessageFormatter<string>
+    {
+        public override string GetMessage(string? message, IMessageFormatterProcessor? formatterProcessor = null) => $"<{message}>";
+    }
+}

--- a/tests/Spectre/CommandLine.Spectre.Tests/Output/MessageFormatterProcessorTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/Output/MessageFormatterProcessorTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Ploch.CommandLine.Spectre.Output;
 
 namespace Ploch.CommandLine.Spectre.Tests.Output;
@@ -75,6 +76,90 @@ public class MessageFormatterProcessorTests
         var processor = new MessageFormatterProcessor([], []);
 
         processor.GetMessageText(42).Should().Be("42");
+    }
+
+    [Fact]
+    public void GetMessageText_should_apply_a_registered_formatter_before_the_markup_tag()
+    {
+        var processor = new MessageFormatterProcessor([new UpperCasingFormatter()], []);
+
+        processor.GetMessageText("value", "underline").Should().Be("[underline]VALUE[/]", "the formatter runs first and the tag wraps its output");
+    }
+
+    [Fact]
+    public void GetMessageText_should_return_an_empty_formattable_string_for_a_null_interpolated_message()
+    {
+        var processor = new MessageFormatterProcessor([], []);
+
+        processor.GetMessageText((FormattableString?)null).ToString(CultureInfo.InvariantCulture).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GetMessageText_should_format_the_arguments_of_an_interpolated_message_through_the_formatters()
+    {
+        var processor = new MessageFormatterProcessor([new UpperCasingFormatter()], []);
+
+        FormattableString message = $"greeting: {"hello"}";
+
+        var result = processor.GetMessageText(message);
+
+        result.ToString(CultureInfo.InvariantCulture).Should().Be("greeting: HELLO", "each argument is passed through the matching formatter");
+    }
+
+    [Fact]
+    public void GetMessageText_should_substitute_an_empty_string_for_a_null_interpolated_argument()
+    {
+        var processor = new MessageFormatterProcessor([new UpperCasingFormatter()], []);
+
+        FormattableString message = $"value: [{(string?)null}]";
+
+        var result = processor.GetMessageText(message);
+
+        result.ToString(CultureInfo.InvariantCulture).Should().Be("value: []");
+    }
+
+    [Fact]
+    public void GetMessageText_should_fall_back_to_ToString_for_an_interpolated_argument_with_no_formatter()
+    {
+        var processor = new MessageFormatterProcessor([], []);
+
+        FormattableString message = $"count: {17}";
+
+        var result = processor.GetMessageText(message);
+
+        result.ToString(CultureInfo.InvariantCulture).Should().Be("count: 17");
+    }
+
+    [Fact]
+    public void GetMessageText_should_wrap_an_interpolated_message_in_the_markup_tag()
+    {
+        var processor = new MessageFormatterProcessor([], []);
+
+        FormattableString message = $"count: {17}";
+
+        var result = processor.GetMessageText(message, "red");
+
+        result.ToString(CultureInfo.InvariantCulture).Should().Be("[red]count: 17[/]");
+    }
+
+    [Fact]
+    public void GetMessageText_should_keep_the_interpolated_arguments_separate_from_the_format_string()
+    {
+        var processor = new MessageFormatterProcessor([], []);
+
+        FormattableString message = $"{1}-{2}";
+
+        var result = processor.GetMessageText(message);
+
+        result.Format.Should().Be("{0}-{1}", "the result stays a composite format string rather than being flattened early");
+        result.GetArguments().Should().Equal("1", "2");
+    }
+
+    /// <summary>A formatter that visibly transforms its input, so a test can prove the formatter was actually applied.</summary>
+    private sealed class UpperCasingFormatter : TypeMessageFormatter<string>
+    {
+        public override string GetMessage(string? message, IMessageFormatterProcessor? formatterProcessor = null) =>
+            message?.ToUpperInvariant() ?? string.Empty;
     }
 
     private sealed class RecordingStringWriter : TypeMessageWriter<string>

--- a/tests/Spectre/CommandLine.Spectre.Tests/Output/MessageWriterTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/Output/MessageWriterTests.cs
@@ -1,0 +1,243 @@
+using System.Collections;
+using System.ComponentModel;
+using Ploch.CommandLine.Spectre.Output;
+using Ploch.CommandLine.Spectre.Tests.Testing;
+
+namespace Ploch.CommandLine.Spectre.Tests.Output;
+
+/// <summary>
+///     Cover for <see cref="EnumerableMessageWriter" />: it is the only writer that has to cope with a null
+///     collection and with the absence of a formatter processor.
+/// </summary>
+public class EnumerableMessageWriterTests
+{
+    [Fact]
+    public void Write_should_report_an_empty_collection_placeholder_when_the_collection_is_null()
+    {
+        using var console = new RecordingConsole();
+
+        new EnumerableMessageWriter(console.Console).Write(null);
+
+        console.Output.Should().Be("No items to display." + Environment.NewLine);
+    }
+
+    [Fact]
+    public void Write_should_write_one_line_per_item_using_ToString_when_no_processor_is_supplied()
+    {
+        using var console = new RecordingConsole();
+
+        string[] items = ["alpha", "beta"];
+
+        new EnumerableMessageWriter(console.Console).Write(items);
+
+        console.Output.Should().Be($"alpha{Environment.NewLine}beta{Environment.NewLine}");
+    }
+
+    [Fact]
+    public void Write_should_route_each_item_through_the_supplied_formatter_processor()
+    {
+        using var console = new RecordingConsole();
+        var processor = new MessageFormatterProcessor([new BracketingFormatter()], []);
+
+        string[] items = ["alpha"];
+
+        new EnumerableMessageWriter(console.Console).Write(items, processor);
+
+        console.Output.Should().Be($"<alpha>{Environment.NewLine}");
+    }
+
+    [Fact]
+    public void Write_should_write_nothing_for_an_empty_collection()
+    {
+        using var console = new RecordingConsole();
+
+        new EnumerableMessageWriter(console.Console).Write(Array.Empty<string>());
+
+        console.Output.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CanHandle_should_accept_collections_and_reject_scalars()
+    {
+        using var console = new RecordingConsole();
+        var writer = new EnumerableMessageWriter(console.Console);
+
+        int[] items = [1];
+
+        writer.CanHandle(items).Should().BeTrue();
+        writer.CanHandle(1).Should().BeFalse();
+        writer.MessageType.Should().Be<IEnumerable>();
+    }
+
+    private sealed class BracketingFormatter : TypeMessageFormatter<string>
+    {
+        public override string GetMessage(string? message, IMessageFormatterProcessor? formatterProcessor = null) => $"<{message}>";
+    }
+}
+
+/// <summary>
+///     Cover for <see cref="FormattableStringMessageWriter" />, which has to fall back to the raw message when no
+///     processor is supplied and stay silent when there is nothing to write.
+/// </summary>
+public class FormattableStringMessageWriterTests
+{
+    [Fact]
+    public void Write_should_render_the_message_through_the_supplied_processor()
+    {
+        using var console = new RecordingConsole();
+        var processor = new MessageFormatterProcessor([new BracketingFormatter()], []);
+
+        new FormattableStringMessageWriter(console.Console).Write($"value: {"x"}", processor);
+
+        console.Output.Should().Be("value: <x>");
+    }
+
+    [Fact]
+    public void Write_should_render_the_raw_message_when_no_processor_is_supplied()
+    {
+        using var console = new RecordingConsole();
+
+        new FormattableStringMessageWriter(console.Console).Write($"value: {"x"}");
+
+        console.Output.Should().Be("value: x");
+    }
+
+    [Fact]
+    public void Write_should_write_nothing_when_the_message_is_null_and_no_processor_is_supplied()
+    {
+        using var console = new RecordingConsole();
+
+        new FormattableStringMessageWriter(console.Console).Write(null);
+
+        console.Output.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Write_should_escape_markup_carried_by_the_interpolated_arguments()
+    {
+        using var console = new RecordingConsole();
+
+        new FormattableStringMessageWriter(console.Console).Write($"{"[red]"}");
+
+        console.Output.Should().Be("[red]", "an argument value must never be reinterpreted as markup");
+    }
+
+    private sealed class BracketingFormatter : TypeMessageFormatter<string>
+    {
+        public override string GetMessage(string? message, IMessageFormatterProcessor? formatterProcessor = null) => $"<{message}>";
+    }
+}
+
+/// <summary>
+///     Cover for <see cref="ExceptionMessageWriter" />, including the substitute exception it renders when asked
+///     to write nothing.
+/// </summary>
+public class ExceptionMessageWriterTests
+{
+    [Fact]
+    public void Write_should_render_the_exception_message()
+    {
+        using var console = new RecordingConsole();
+
+        new ExceptionMessageWriter(console.Console).Write(new InvalidOperationException("the failure detail"));
+
+        console.Output.Should().Contain("the failure detail");
+    }
+
+    [Fact]
+    public void Write_should_render_a_placeholder_exception_when_the_message_is_null()
+    {
+        using var console = new RecordingConsole();
+
+        new ExceptionMessageWriter(console.Console).Write(null);
+
+        console.Output.Should().Contain("No exception to display.");
+    }
+}
+
+/// <summary>
+///     Cover for <see cref="StringMessageWriter" />, whose only real behaviour is the null substitution.
+/// </summary>
+public class StringMessageWriterTests
+{
+    [Fact]
+    public void Write_should_write_the_message_verbatim()
+    {
+        using var console = new RecordingConsole();
+
+        new StringMessageWriter(console.Console).Write("[not markup]");
+
+        console.Output.Should().Be("[not markup]", "this writer bypasses markup parsing");
+    }
+
+    [Fact]
+    public void Write_should_write_nothing_for_a_null_message()
+    {
+        using var console = new RecordingConsole();
+
+        new StringMessageWriter(console.Console).Write(null);
+
+        console.Output.Should().BeEmpty();
+    }
+}
+
+/// <summary>
+///     Cover for <see cref="StringMessageFormatter" />, whose only real behaviour is the null substitution.
+/// </summary>
+public class StringMessageFormatterTests
+{
+    [Fact]
+    public void GetMessage_should_return_the_message_unchanged()
+    {
+        new StringMessageFormatter().GetMessage("value").Should().Be("value");
+    }
+
+    [Fact]
+    public void GetMessage_should_substitute_an_empty_string_for_a_null_message()
+    {
+        new StringMessageFormatter().GetMessage(null).Should().BeEmpty();
+    }
+}
+
+/// <summary>
+///     Cover for <see cref="Win32ExceptionMessageFormatter" />, which adds the native error code to the rendered text.
+/// </summary>
+public class Win32ExceptionMessageFormatterTests
+{
+    [Fact]
+    public void GetMessage_should_include_the_native_error_code()
+    {
+        var formatter = new Win32ExceptionMessageFormatter();
+
+        var result = formatter.GetMessage(new Win32Exception(5));
+
+        result.Should().Contain("<Error Code: 5>").And.Contain(nameof(Win32Exception));
+    }
+
+    [Fact]
+    public void GetMessage_should_append_the_inner_exception_details_only_when_there_is_one()
+    {
+        var formatter = new Win32ExceptionMessageFormatter();
+
+        formatter.GetMessage(new Win32Exception(2, "no inner")).Should().NotContain("Inner exception");
+        formatter.GetMessage(new Win32Exception("outer", new InvalidOperationException("inner detail")))
+                 .Should()
+                 .Contain("Inner exception")
+                 .And.Contain("inner detail");
+    }
+
+    [Fact]
+    public void CanHandle_should_accept_only_Win32_exceptions()
+    {
+        var formatter = new Win32ExceptionMessageFormatter();
+
+        formatter.CanHandle(new Win32Exception(1)).Should().BeTrue();
+        formatter.CanHandle(new InvalidOperationException()).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsWriter_should_be_false_because_the_formatter_only_produces_text()
+    {
+        new Win32ExceptionMessageFormatter().IsWriter.Should().BeFalse();
+    }
+}

--- a/tests/Spectre/CommandLine.Spectre.Tests/Output/TypedMessageHandlerDefaultsTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/Output/TypedMessageHandlerDefaultsTests.cs
@@ -1,0 +1,75 @@
+using Ploch.CommandLine.Spectre.Output;
+
+namespace Ploch.CommandLine.Spectre.Tests.Output;
+
+/// <summary>
+///     Cover for the default implementations on <see cref="IMessageWriter{TMessage}" /> and
+///     <see cref="IMessageFormatter{TMessage}" />. They are the contract an implementer gets for free when they
+///     implement the generic interface directly instead of deriving from <see cref="TypeMessageWriter{TMessage}" />
+///     or <see cref="TypeMessageFormatter{TMessage}" />: type-based handling, and an object-typed entry point that
+///     forwards to the strongly-typed one.
+/// </summary>
+public class TypedMessageHandlerDefaultsTests
+{
+    [Fact]
+    public void IMessageWriter_should_derive_the_message_type_from_its_type_argument()
+    {
+        IMessageWriter<string> writer = new DirectWriter();
+
+        writer.MessageType.Should().Be<string>("the generic interface supplies the message type without the implementer restating it");
+    }
+
+    [Fact]
+    public void IMessageWriter_should_accept_only_messages_of_its_type_argument()
+    {
+        IMessageWriter<string> writer = new DirectWriter();
+
+        writer.CanHandle("text").Should().BeTrue();
+        writer.CanHandle(42).Should().BeFalse();
+        writer.CanHandle(null).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IMessageFormatter_should_forward_an_object_typed_message_to_the_strongly_typed_overload()
+    {
+        IMessageFormatter<string> formatter = new DirectFormatter();
+
+        formatter.GetMessage((object?)"text").Should().Be("formatted:text");
+    }
+
+    /// <summary>
+    ///     Implements the generic writer interface directly and provides the non-generic <see cref="IMessageHandler" />
+    ///     members explicitly, so the generic interface's own defaults are the ones under test.
+    /// </summary>
+    private sealed class DirectWriter : IMessageWriter<string>
+    {
+        /// <summary>Deliberately unrelated to <c>string</c>, so a test can tell the two views of the writer apart.</summary>
+        Type IMessageHandler.MessageType => typeof(object);
+
+        /// <summary>Deliberately always false, so a test can tell the two views of the writer apart.</summary>
+        bool IMessageHandler.CanHandle(object? message) => false;
+
+        public void Write(object? message, IMessageFormatterProcessor? formatterProcessor = null)
+        {
+            // Not exercised: this test covers the interface defaults, not the writing itself.
+        }
+
+        public void Write(string? message, IMessageFormatterProcessor? formatterProcessor = null)
+        {
+            // Not exercised: this test covers the interface defaults, not the writing itself.
+        }
+    }
+
+    /// <summary>Implements only the strongly-typed formatting method, leaving the object-typed one to the interface default.</summary>
+    private sealed class DirectFormatter : IMessageFormatter<string>
+    {
+        public Type MessageType => typeof(string);
+
+        public bool CanHandle(object? message) => message is string;
+
+        string IMessageFormatter.GetMessage(object? message, IMessageFormatterProcessor formatterProcessor) =>
+            GetMessage((string?)message, formatterProcessor);
+
+        public string GetMessage(string? message, IMessageFormatterProcessor? formatterProcessor = null) => $"formatted:{message}";
+    }
+}

--- a/tests/Spectre/CommandLine.Spectre.Tests/Testing/GlobalConsoleState.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/Testing/GlobalConsoleState.cs
@@ -1,0 +1,15 @@
+namespace Ploch.CommandLine.Spectre.Tests.Testing;
+
+/// <summary>
+///     Groups the tests that mutate process-wide state — <c>AnsiConsole.Console</c>, <c>Console.In</c> and
+///     <c>EnvironmentSettings.Current</c> — so they never run concurrently with one another.
+/// </summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class GlobalConsoleState
+{
+    public const string Name = "Global console state";
+
+    private GlobalConsoleState()
+    {
+    }
+}

--- a/tests/Spectre/CommandLine.Spectre.Tests/Testing/NoOpOutput.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/Testing/NoOpOutput.cs
@@ -1,0 +1,46 @@
+using Ploch.CommandLine.Spectre.Output;
+using Spectre.Console.Rendering;
+
+namespace Ploch.CommandLine.Spectre.Tests.Testing;
+
+/// <summary>
+///     An <see cref="IOutput" /> that discards everything, so a test does not write to the console. Every member is
+///     virtual, so a test can override just the one call it needs to observe.
+/// </summary>
+internal class NoOpOutput : IOutput
+{
+    public virtual IOutput EndLine() => this;
+
+    public virtual IOutput MarkupInterpolated(FormattableString value) => this;
+
+    public virtual IOutput MarkupLineInterpolated(FormattableString value) => this;
+
+    public virtual IOutput Write<TMessage>(TMessage message, IFormatProvider? format = null) => this;
+
+    public virtual IOutput Write(IRenderable renderable) => this;
+
+    public virtual IOutput WriteBold<TMessage>(TMessage? message) => this;
+
+    public virtual IOutput WriteBoldLine<TMessage>(TMessage? message) => this;
+
+    public virtual IOutput WriteError<TMessage>(TMessage? message) => this;
+
+    public virtual IOutput WriteErrorLine<TMessage>(TMessage? message) => this;
+
+    public IOutput WriteException<TException>(TException? exception) where TException : Exception
+    {
+        OnException(exception);
+
+        return this;
+    }
+
+    public virtual IOutput WriteLine() => this;
+
+    public virtual IOutput WriteLine<TMessage>(TMessage message) => this;
+
+    /// <summary>Called for every exception written; overridden by tests that need to observe the call.</summary>
+    protected virtual void OnException(Exception? exception)
+    {
+        // Discarded by default.
+    }
+}

--- a/tests/Spectre/CommandLine.Spectre.Tests/Testing/NoOpOutput.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/Testing/NoOpOutput.cs
@@ -5,7 +5,9 @@ namespace Ploch.CommandLine.Spectre.Tests.Testing;
 
 /// <summary>
 ///     An <see cref="IOutput" /> that discards everything, so a test does not write to the console. Every member is
-///     virtual, so a test can override just the one call it needs to observe.
+///     virtual so a test can override just the call it needs to observe, except <see cref="WriteException{TException}" />:
+///     its generic constraint makes it awkward to override, so it forwards to the non-generic
+///     <see cref="OnException" /> hook instead.
 /// </summary>
 internal class NoOpOutput : IOutput
 {

--- a/tests/Spectre/CommandLine.Spectre.Tests/Testing/RecordingConsole.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/Testing/RecordingConsole.cs
@@ -1,0 +1,40 @@
+using System.Globalization;
+using Spectre.Console;
+
+namespace Ploch.CommandLine.Spectre.Tests.Testing;
+
+/// <summary>
+///     An <see cref="IAnsiConsole" /> backed by a <see cref="StringWriter" />, so a test can assert on what was
+///     actually rendered. Colours and ANSI escapes are switched off, which means the captured text is the plain
+///     text a reader would see — markup that Spectre parsed is applied and then stripped, markup that Spectre
+///     could not parse would surface as an exception rather than as literal brackets.
+/// </summary>
+internal sealed class RecordingConsole : IDisposable
+{
+    private readonly StringWriter _writer = new(CultureInfo.InvariantCulture);
+
+    public RecordingConsole()
+    {
+        Console = AnsiConsole.Create(new AnsiConsoleSettings
+                                     {
+                                         Ansi = AnsiSupport.No,
+                                         ColorSystem = ColorSystemSupport.NoColors,
+                                         Interactive = InteractionSupport.No,
+                                         Out = new AnsiConsoleOutput(_writer)
+                                     });
+
+        // A narrow profile would wrap the rendered text and break substring assertions.
+        Console.Profile.Width = 500;
+        Console.Profile.Height = 500;
+    }
+
+    public IAnsiConsole Console { get; }
+
+    /// <summary>Gets everything written so far, exactly as rendered.</summary>
+    public string Output => _writer.ToString();
+
+    /// <summary>Gets the rendered text with line breaks and padding collapsed, for whitespace-insensitive assertions.</summary>
+    public string FlatOutput => string.Join(" ", Output.Split('\n', '\r', ' ').Where(part => part.Length > 0));
+
+    public void Dispose() => _writer.Dispose();
+}

--- a/tests/Spectre/CommandLine.Spectre.Tests/Testing/RecordingConsole.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/Testing/RecordingConsole.cs
@@ -1,23 +1,35 @@
 using System.Globalization;
+using System.Text.RegularExpressions;
 using Spectre.Console;
 
 namespace Ploch.CommandLine.Spectre.Tests.Testing;
 
 /// <summary>
 ///     An <see cref="IAnsiConsole" /> backed by a <see cref="StringWriter" />, so a test can assert on what was
-///     actually rendered. Colours and ANSI escapes are switched off, which means the captured text is the plain
-///     text a reader would see — markup that Spectre parsed is applied and then stripped, markup that Spectre
-///     could not parse would surface as an exception rather than as literal brackets.
+///     actually rendered. Colours are switched off and escape sequences are stripped when the output is read, which
+///     leaves the plain text a reader would see: markup that Spectre parsed is applied and then removed, while
+///     markup Spectre could not parse would surface as an exception rather than as literal brackets.
 /// </summary>
+/// <remarks>
+///     ANSI is switched on deliberately rather than off. With it off, Spectre falls back to the console API on
+///     Windows and still emits escape sequences for decorations such as bold and italic elsewhere, so the captured
+///     text differs between a developer machine and the Linux CI runner. Turning it on and stripping the sequences
+///     when the output is read gives the same visible text everywhere.
+/// </remarks>
 internal sealed class RecordingConsole : IDisposable
 {
+    private const char Escape = (char)27;
+
+    /// <summary>Matches a CSI escape sequence. The escape character comes from its code point, so none appears in this file.</summary>
+    private static readonly Regex EscapeSequence = new(Escape + @"\[[0-9;?]*[ -/]*[@-~]", RegexOptions.Compiled);
+
     private readonly StringWriter _writer = new(CultureInfo.InvariantCulture);
 
     public RecordingConsole()
     {
         Console = AnsiConsole.Create(new AnsiConsoleSettings
                                      {
-                                         Ansi = AnsiSupport.No,
+                                         Ansi = AnsiSupport.Yes,
                                          ColorSystem = ColorSystemSupport.NoColors,
                                          Interactive = InteractionSupport.No,
                                          Out = new AnsiConsoleOutput(_writer)
@@ -30,11 +42,11 @@ internal sealed class RecordingConsole : IDisposable
 
     public IAnsiConsole Console { get; }
 
-    /// <summary>Gets everything written so far, exactly as rendered.</summary>
-    public string Output => _writer.ToString();
+    /// <summary>Gets the visible text written so far, with any ANSI escape sequences removed.</summary>
+    public string Output => EscapeSequence.Replace(RawOutput, string.Empty);
 
-    /// <summary>Gets the rendered text with line breaks and padding collapsed, for whitespace-insensitive assertions.</summary>
-    public string FlatOutput => string.Join(" ", Output.Split('\n', '\r', ' ').Where(part => part.Length > 0));
+    /// <summary>Gets everything written so far, escape sequences included.</summary>
+    public string RawOutput => _writer.ToString();
 
     public void Dispose() => _writer.Dispose();
 }

--- a/tests/Spectre/CommandLine.UseCases.Tests/GlobalUsings.cs
+++ b/tests/Spectre/CommandLine.UseCases.Tests/GlobalUsings.cs
@@ -1,0 +1,2 @@
+// Global usings for Ploch.CommandLine.UseCases.Tests
+global using FluentAssertions;

--- a/tests/Spectre/CommandLine.UseCases.Tests/Ploch.CommandLine.UseCases.Tests.csproj
+++ b/tests/Spectre/CommandLine.UseCases.Tests/Ploch.CommandLine.UseCases.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(TargetFrameworkVersion)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
+    <Platforms>AnyCPU;x64</Platforms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\ploch-common\src\TestingSupport.XUnit3.AutoMoq\Ploch.TestingSupport.XUnit3.AutoMoq.csproj" />
+    <ProjectReference Include="..\..\..\src\Spectre\CommandLine.UseCases\Ploch.CommandLine.UseCases.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Spectre/CommandLine.UseCases.Tests/UseCaseAsyncCommandTests.cs
+++ b/tests/Spectre/CommandLine.UseCases.Tests/UseCaseAsyncCommandTests.cs
@@ -1,0 +1,200 @@
+using System.Globalization;
+using Ardalis.Result;
+using Ploch.CommandLine.Spectre.Commands;
+using Ploch.CommandLine.Spectre.Output;
+using Ploch.TestingSupport.XUnit3.AutoMoq;
+using Spectre.Console;
+using Spectre.Console.Cli;
+using Spectre.Console.Rendering;
+
+namespace Ploch.CommandLine.UseCases.Tests;
+
+/// <summary>
+///     Cover for the command base that bridges Spectre.Console.Cli to a use case. Its job is to build the request
+///     from the validated settings, forward the cancellation token, and map the <see cref="Result{T}" /> the use
+///     case returns onto an exit code.
+/// </summary>
+public class UseCaseAsyncCommandTests
+{
+    [Theory]
+    [AutoMockData]
+    public async Task ExecuteAsync_should_return_success_and_report_completion_when_the_use_case_succeeds(CommandContext context)
+    {
+        var output = new RecordingOutput();
+        var command = CreateCommand(output, _ => Result<string>.Success("done"));
+
+        var result = await command.ExecuteAsync(context, new StubSettings(), CancellationToken.None);
+
+        result.Should().Be((int)ExitCode.Success);
+        output.Written.Should().ContainMatch("*Use case completed successfully*");
+    }
+
+    [Theory]
+    [AutoMockData]
+    public async Task ExecuteAsync_should_return_error_and_report_the_errors_when_the_use_case_fails(CommandContext context)
+    {
+        var output = new RecordingOutput();
+        var command = CreateCommand(output, _ => Result<string>.Error("the widget jammed"));
+
+        var result = await command.ExecuteAsync(context, new StubSettings(), CancellationToken.None);
+
+        result.Should().Be((int)ExitCode.Error);
+        output.Written.Should().ContainMatch("*Use case failed*the widget jammed*");
+        output.Written.Should().NotContainMatch("*completed successfully*");
+    }
+
+    [Theory]
+    [AutoMockData]
+    public async Task ExecuteAsync_should_return_error_when_the_use_case_reports_not_found(CommandContext context)
+    {
+        var output = new RecordingOutput();
+        var command = CreateCommand(output, _ => Result<string>.NotFound());
+
+        var result = await command.ExecuteAsync(context, new StubSettings(), CancellationToken.None);
+
+        result.Should().Be((int)ExitCode.Error, "any unsuccessful result maps onto the failure path");
+    }
+
+    [Theory]
+    [AutoMockData]
+    public async Task ExecuteAsync_should_pass_the_request_built_from_the_settings_to_the_use_case(CommandContext context)
+    {
+        string? receivedRequest = null;
+        var command = CreateCommand(new RecordingOutput(),
+                                    request =>
+                                    {
+                                        receivedRequest = request;
+
+                                        return Result<string>.Success("done");
+                                    });
+
+        await command.ExecuteAsync(context, new StubSettings { Target = "widget-42" }, CancellationToken.None);
+
+        receivedRequest.Should().Be("request-for-widget-42", "CreateRequest turns the settings into the use case request");
+    }
+
+    [Theory]
+    [AutoMockData]
+    public async Task ExecuteAsync_should_forward_the_cancellation_token_to_the_use_case(CommandContext context)
+    {
+        var useCase = new StubUseCase(_ => Result<string>.Success("done"));
+        var command = CreateCommand(new RecordingOutput(), useCase);
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        await command.ExecuteAsync(context, new StubSettings(), cancellationTokenSource.Token);
+
+        useCase.ReceivedToken.Should().Be(cancellationTokenSource.Token, "the use case has to be able to honour cancellation");
+    }
+
+    [Theory]
+    [AutoMockData]
+    public async Task ExecuteAsync_should_echo_the_settings_and_name_the_use_case_before_running_it(CommandContext context)
+    {
+        var output = new RecordingOutput();
+        var command = CreateCommand(output, _ => Result<string>.Success("done"));
+
+        await command.ExecuteAsync(context, new StubSettings { Target = "widget-42" }, CancellationToken.None);
+
+        output.Written.Should().ContainMatch($"*Starting use case*{nameof(StubUseCase)}*", "the progress line names the use case being run");
+        output.Written.Should().ContainMatch("*Target*widget-42*", "the settings the command received are echoed back");
+    }
+
+    [Theory]
+    [AutoMockData]
+    public async Task ExecuteAsync_should_let_an_overridden_success_handler_choose_the_exit_code(CommandContext context)
+    {
+        var command = new CustomExitCodeCommand(new RecordingOutput(), new StubUseCase(_ => Result<string>.Success("done")));
+
+        var result = await command.ExecuteAsync(context, new StubSettings(), CancellationToken.None);
+
+        result.Should().Be((int)ExitCode.InvalidInput, "ProcessSuccessResponse is a virtual extension point");
+    }
+
+    private static StubUseCaseCommand CreateCommand(RecordingOutput output, Func<string, Result<string>> execute) =>
+        CreateCommand(output, new StubUseCase(execute));
+
+    private static StubUseCaseCommand CreateCommand(RecordingOutput output, StubUseCase useCase) => new(output, useCase);
+
+    private sealed class StubSettings : CommandSettings
+    {
+        public string Target { get; init; } = "default-target";
+    }
+
+    private sealed class StubUseCase(Func<string, Result<string>> execute) : IResultUseCase<string, string>
+    {
+        public CancellationToken ReceivedToken { get; private set; }
+
+        public Task<Result<string>> ExecuteAsync(string request, CancellationToken cancellationToken = default)
+        {
+            ReceivedToken = cancellationToken;
+
+            return Task.FromResult(execute(request));
+        }
+    }
+
+    private class StubUseCaseCommand(RecordingOutput output, StubUseCase useCase)
+        : UseCaseAsyncCommand<StubSettings, StubUseCase, string, string>(output,
+                                                                         useCase,
+                                                                         new CommandArgumentsRootProcessor([]),
+                                                                         new PassThroughValidator(),
+                                                                         new ThrowingExceptionHandler())
+    {
+        protected override string CreateRequest(StubSettings commandSettings) => $"request-for-{commandSettings.Target}";
+    }
+
+    private sealed class CustomExitCodeCommand(RecordingOutput output, StubUseCase useCase) : StubUseCaseCommand(output, useCase)
+    {
+        protected override ExitCode ProcessSuccessResponse(Result<string> result) => ExitCode.InvalidInput;
+    }
+
+    private sealed class PassThroughValidator : ICommandSettingsValidator<StubSettings>
+    {
+        public ValidationResult Validate(CommandContext context, StubSettings settings) => ValidationResult.Success();
+    }
+
+    /// <summary>Fails the test loudly rather than swallowing an unexpected exception into an exit code.</summary>
+    private sealed class ThrowingExceptionHandler : IExceptionHandler
+    {
+        public int HandleException(Exception ex) => throw new InvalidOperationException("The command raised an unexpected exception.", ex);
+    }
+
+    /// <summary>Captures the rendered text so the command's reporting can be asserted without a console.</summary>
+    private sealed class RecordingOutput : IOutput
+    {
+        public List<string> Written { get; } = [];
+
+        public IOutput EndLine() => this;
+
+        public IOutput MarkupInterpolated(FormattableString value) => Record(value.ToString(CultureInfo.InvariantCulture));
+
+        public IOutput MarkupLineInterpolated(FormattableString value) => Record(value.ToString(CultureInfo.InvariantCulture));
+
+        public IOutput Write(IRenderable renderable) => this;
+
+        public IOutput Write<TMessage>(TMessage message, IFormatProvider? format = null) => Record(message?.ToString());
+
+        public IOutput WriteBold<TMessage>(TMessage? message) => Record(message?.ToString());
+
+        public IOutput WriteBoldLine<TMessage>(TMessage? message) => Record(message?.ToString());
+
+        public IOutput WriteError<TMessage>(TMessage? message) => Record(message?.ToString());
+
+        public IOutput WriteErrorLine<TMessage>(TMessage? message) => Record(message?.ToString());
+
+        public IOutput WriteException<TException>(TException? exception) where TException : Exception => Record(exception?.Message);
+
+        public IOutput WriteLine() => this;
+
+        public IOutput WriteLine<TMessage>(TMessage message) => Record(message?.ToString());
+
+        private RecordingOutput Record(string? text)
+        {
+            if (text is not null)
+            {
+                Written.Add(text);
+            }
+
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
## Describe your changes

PR #11 clears every SonarCloud quality-gate condition except one: `new_coverage` at **40.5%** against a required **80%**. This branch closes that gap by finishing the work of #13 — building out the `Ploch.CommandLine.Spectre` test suite.

**Suite: 75 → 201 tests. Local Coverlet across the `Ploch.CommandLine.*` assemblies: 398/399 lines (99.75%) and 149/158 conditions (94.30%), up from 173/392 lines (44.13%) and 56/158 conditions (35.44%).**

No production code was touched. No analyser rule was relaxed, no `[ExcludeFromCodeCoverage]` added, no `coverage.exclusions` widened.

### New test projects

Two packages had no test project at all, so their code was never even instrumented:

| Project | Covers |
|---|---|
| `Ploch.CommandLine.Spectre.Serilog.Tests` | `LoggerConfigurationExtensions`, `SerilogLoggingConfigurator` |
| `Ploch.CommandLine.UseCases.Tests` | `UseCaseAsyncCommand` |

Both follow the existing test-project shape (xUnit v3 + FluentAssertions + AutoFixture via `Ploch.TestingSupport.XUnit3.AutoMoq`) and are registered in `Ploch.CommandLine.Spectre.slnx`.

### What is now covered, and what each test actually proves

**`AppBuilder` (was 0/52 lines)** — every fluent method is asserted to return the same builder *and* to land its value on `ConsoleAppInfo`. `ConfigureCommandApp` is exercised end to end: the test builds the real host, runs a probe command through Spectre.Console.Cli, and asserts that services registered via `ConfigureServices`, `ConfigureHost` and `AddServicesBundle` resolve inside the running command; that configuration added via `ConfigureAppConfiguration` is readable from it; that the `CancellationTokenSource` the builder was constructed with is the one the command receives; and that `AppBuilder.Create(args)` feeds those arguments into the host configuration. This is the test that would catch a break anywhere in the registrar → resolver → host chain.

**`LoggerConfigurationExtensions` (was 0/41 lines)** — the headline test writes Debug/Information/Warning/Error/Fatal events and asserts the **errors file contains the warning, error and fatal messages and *not* the informational one**. That is the exact regression guard for the defect PR #11 fixed, where the error sink sat outside its filtered sub-logger and the "errors" file received every event. Also covered: the minimum level read from configuration, the Information default, the custom output template, and the process-name file-naming default.

**`SerilogLoggingConfigurator`** — asserts Serilog's `ILogger` is registered **exactly once** (the double-registration defect) and that the caller's output template survives registration and reaches the file on disk (the symptom that defect produced).

**`AnsiConsoleMarkupOutput` (was 1/39 lines, 0/28 conditions)** — rendered through Spectre's own console over a `StringWriter`, so the assertions are on real output. Covers every dispatch branch of `Write`/`WriteLine`, markup escaping of interpolated arguments, the format-provider overload, the `IRenderable` overload, exception rendering, and chaining. Includes a direct regression guard for the double-write defect: a writer-handled message must invoke the writer exactly once and leave the fallback path silent.

**`MessageFormatterProcessor`** — the previously untested `FormattableString` overload: arguments routed through registered formatters, null arguments becoming empty strings, ToString fallback, markup-tag wrapping, and the result staying a composite format string rather than being flattened early.

**`UseCaseAsyncCommand` (was 0/13 lines)** — success, `Error` and `NotFound` results mapped onto exit codes; the request built by `CreateRequest` reaching the use case; the cancellation token forwarded; the settings echoed; and `ProcessSuccessResponse` honoured as a virtual extension point.

**`CommandAppExecutor`** — `Run` and `RunAsync` both honour `PauseBeforeExit` identically (the defect where only the async path did), verified by a stdin stand-in that records being read, plus the prompt text on the console.

**Also covered:** `DependencyInjectionTypeRegistrar` / `DependencyInjectionTypeResolver` (all three registration modes resolve, null factory rejected, null and unknown types return null, `Dispose` disposes the host), `ConsoleAppInfoExtensions.PrintAppInfo` (banner drawn once — the duplicated-FigletText defect — version appended only when set, description line present only when non-empty), `DefaultExceptionHandler` (a `Win32Exception`, nested or not, bypasses the markup pipeline and does not throw on text containing `[`), `CommandSettingsValidator`, `CommandAppConfigurator`, `FluentCommandSettingsValidator` (including the no-fluent-validator fallback), and the enumerable/string/exception/`FormattableString` writers and formatters.

## Design Decisions

- **`RecordingConsole` over `Spectre.Console.Testing`.** Output is captured with `AnsiConsole.Create(...)` writing to a `StringWriter`, so assertions are on real rendered text. This needs no new package reference; adding `Spectre.Console.Testing` to `Directory.Packages.props` would have been the only alternative.
- **ANSI is enabled in the recording console and the escape sequences are stripped on read.** With ANSI off, Spectre falls back to the console API on Windows but still emits escapes for decorations such as bold and italic elsewhere, so six assertions passed locally and failed on the Linux runner with an invisible difference. Turning ANSI on and stripping the sequences gives the same visible text on every platform; the raw text stays available via `RawOutput`.
- **Markup tags asserted through a recording `IMessageFormatterProcessor`, not through escape codes.** With colours disabled a `[red]` tag renders as nothing, so `WriteError`/`WriteBold` are verified by recording the tag the adapter asks the processor for — and separately by asserting the text that reaches the console. Asserting on raw ANSI escape sequences would be brittle.
- **Tests that mutate process-wide state (`AnsiConsole.Console`, `Console.In`, `EnvironmentSettings.Current`) live in one non-parallel xUnit collection** (`GlobalConsoleState`) and restore the previous value in `Dispose`. `EnvironmentSettings.Reset()` — added in PR #11 precisely for this — is called on teardown.
- **The `AppBuilder` probe command reports through a static slot rather than a registered service.** `AppBuilder.ConfigureServices`, `ConfigureHost` and `ConfigureAppConfiguration` each keep only the **last** delegate they are given, so a helper that registered the probe itself would silently overwrite whatever the test under it had configured. The static is safe because the class runs in the non-parallel collection. (The last-wins behaviour is existing production behaviour; it is left alone here.)
- **The last-call-wins contract is pinned by characterisation tests, not endorsed.** `AppBuilder.ConfigureServices`, `ConfigureHost` and `ConfigureAppConfiguration` each keep only the last delegate they are given, while `IHostBuilder` and `AddServicesBundle` are additive. Three tests call each method twice and assert the earlier delegate never runs, so changing that becomes a visible decision rather than a silent one. Raised as #22.
- **Coverage is measured, not manufactured.** Every test asserts observable behaviour and can fail if that behaviour regresses. Nothing was added purely to execute a line.

## Deliberately left uncovered

- **`Win32ExceptionMessageFormatter.GetFormattedExceptionText`** (1 line) — a `protected static` method with no caller anywhere in the repository. Covering it would mean subclassing the formatter purely to reach dead code; it should be deleted instead.
- **The `exception?.` null branches in `BaseExceptionMessageFormatter.GetExceptionText` and `Win32ExceptionMessageFormatter.GetExceptionText`** (3 conditions) — unreachable: `GetMessage` calls `message.NotNull()` before dispatching, so the null side of those operators cannot be taken through the public API.
- **Pure declaration files** — `IMessageFormatterProcessor`, `IMessageHandler`, `IResultUseCase`, `IUseCase`, `IEnvironmentSettingsLoader`, `IOutput`, `ICommandAppExecutor`, `ICommandAppConfigurator` and similar carry no executable statements. `IMessageWriter<T>` and `IMessageFormatter<T>` do have default implementations, and those *are* covered.
- **The `Console.CancelKeyPress` handler body in `AppBuilder.Create`** — it only runs on a real Ctrl+C.

## Defects found while writing these tests (not fixed here)

Both are production behaviour changes, so they are filed rather than fixed on a test-only branch.

- **#20 — `IOutput.Write(someException)` throws `InvalidCastException` on the DI-wired pipeline.** `MessageFormatterProcessor.WriteMessage` picks the writer from the original message but hands it the *formatted string*, and `TypeMessageWriter<Exception>` then casts that string to `Exception`. Reproduced against the real container.
- **#22 — `AppBuilder.ConfigureServices`, `ConfigureHost` and `ConfigureAppConfiguration` silently discard all but the last delegate.** Surprising next to the additive `IHostBuilder` methods and the additive `AddServicesBundle`; the failure surfaces later as an unresolvable dependency inside a command. Pinned by characterisation tests here.

## Testing

- `dotnet build ./Ploch.CommandLine.Spectre.slnx -c Release` — **0 errors, 0 warnings**.
- `dotnet test ./Ploch.CommandLine.Spectre.slnx -c Release` — **all 201 `Ploch.CommandLine.*` tests pass**, 0 failures (`Ploch.CommandLine.Spectre.Tests` 181, `Ploch.CommandLine.Spectre.Serilog.Tests` 9, `Ploch.CommandLine.UseCases.Tests` 7, `Ploch.CommandLine.Spectre.FluentValidation.Tests` 4).
- Coverage with `-p:CollectCoverage=true`, cobertura merged across the four test projects and scoped to `Ploch.CommandLine.*`:

  | | Before | After |
  |---|---|---|
  | Lines | 173/392 (44.13%) | **398/399 (99.75%)** |
  | Conditions | 56/158 (35.44%) | **149/158 (94.30%)** |
  | Tests | 75 | **201** |

  (The line total rises from 392 to 399 because `UseCaseAsyncCommand` was not instrumented at all before — it had no test project referencing it.)

## Issue ticket number and link

- Refs #13 — https://github.com/mrploch/ploch-commandline/issues/13
- Follow-ups filed: #20 — https://github.com/mrploch/ploch-commandline/issues/20 and #22 — https://github.com/mrploch/ploch-commandline/issues/22

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? — n/a
- [ ] Will this be part of a product update? — no user-visible change; tests only

## Review

CodeAnt raised two findings on the first push; both were accepted, fixed in commit `9949863`, replied to on the thread and resolved:

| Finding | Resolution |
|---|---|
| Nothing covered the builder's repeated-call behaviour | Three characterisation tests added; design question filed as #22 |
| `NoOpOutput` summary claimed every member is virtual, but `WriteException` is not | Summary corrected to describe the `OnException` hook |

SonarCloud quality gate on this PR: **Passed** — reliability 1, security 1, maintainability 1, duplications 0.0%, hotspots reviewed 100%, zero security hotspots to review.
