### PR TITLE
chore(solution): Add SonarQube for IDE connected-mode binding

### DIFF
--- a/.sonarlint/connectedMode.json
+++ b/.sonarlint/connectedMode.json
@@ -1,0 +1,4 @@
+{
+  "sonarCloudOrganization": "mrploch",
+  "projectKey": "mrploch_ploch-commandline"
+}


### PR DESCRIPTION
## **User description**
## Describe your changes

Adds `.sonarlint/connectedMode.json`, binding the repository to the `mrploch_ploch-commandline` SonarCloud project.

With connected mode, SonarQube for IDE applies the project's actual quality profile, rule selection, file exclusions and issue statuses inside Rider — so a finding shows up while you are writing the code rather than after CI has run. That closes the loop that this repository has been missing: SonarCloud analysis only started working today (see #12 and the inline workflow in PR #11), and until now there was no way to see its rules locally at all.

Neither this repository nor `ploch-common` had this file.

### Why it is committed rather than local-only

This is the *shared* connected-mode configuration. Committing it means every clone inherits the binding without each developer configuring it by hand. It contains no credentials — the authentication token lives in the IDE's own settings, never in the repository.

`.gitignore` already excludes `.sonarqube/**` (scanner working directory) and `**/.idea/**/sonarlint/` (per-user IDE state), but not `.sonarlint/` at the repository root, so this file is tracked as intended.

## Issue ticket number and link

- Refs #24 — https://github.com/mrploch/ploch-commandline/issues/24

Base branch is `#3-spectre-console-initial`, not `main` — PR #11 has not merged yet. GitHub will retarget this automatically once it does.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests. — Not applicable: a two-key IDE configuration file, no product code
- [ ] Do we need to implement analytics? — No
- [x] Will this be part of a product update? — No, developer tooling only

## Testing

**Please verify this one in Rider before merging — I could not.**

The JSON parses, and both values are confirmed correct against the platform: the project key `mrploch_ploch-commandline` is the one CI passes as `/k:` and the one `search_my_sonarqube_projects` returns, and the organisation `mrploch` is the value of the org-level `SONAR_ORGANIZATION` variable that CI passes as `/o:`.

What I could **not** confirm is the exact property *names* in this file. I checked the SonarSource documentation through Context7 and it returned connected-mode concepts and IntelliJ plugin internals, but not the schema for the shared configuration file. The `projectKey` field is corroborated independently — the SonarQube MCP server's own project-resolution guidance names `.sonarlint/connectedMode.json` and that field explicitly. `sonarCloudOrganization` is the key I believe is correct but could not verify from an authoritative source.

If it is wrong, the failure mode is benign: Rider simply will not offer the binding, rather than binding to anything incorrect. The authoritative fix is one click — in Rider, bind the project through **SonarQube for IDE → Connected Mode**, then use its **share configuration** action, which regenerates this file in the correct format. If Rider produces something different from what is here, its version wins and this should be corrected.


___

## **CodeAnt-AI Description**
Apply the repository’s SonarCloud rules directly in supported IDEs

### What Changed
- IDE analysis is now connected to the repository’s SonarCloud project
- Developers can see the same quality rules and findings locally before submitting changes

### Impact
`✅ Earlier code-quality feedback`
`✅ Consistent IDE and CI analysis`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
