### PR TITLE
ci(github-actions): Pin the Sonar scanner and enforce the quality gate

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -13,6 +13,12 @@
       "commands": [
         "docfx"
       ]
+    },
+    "dotnet-sonarscanner": {
+      "version": "11.2.1",
+      "commands": [
+        "dotnet-sonarscanner"
+      ]
     }
   }
 }

--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -116,25 +116,33 @@ jobs:
       # (no continue-on-error). SonarCloud is a required quality gate on this
       # repository - do not "align" these steps with ploch-common's non-blocking
       # variant. See PR for issue #7.
-      - name: Install SonarCloud Scanner
-        run: dotnet tool install --global dotnet-sonarscanner
-      - name: Install dotnet-coverage
-        run: dotnet tool install --global dotnet-coverage
+      #
+      # No tool install step: dotnet-sonarscanner is pinned in .config/dotnet-tools.json
+      # and restored by the "Restore .NET tools" step above. An unpinned
+      # `dotnet tool install --global` silently picks up new scanner majors, which changes
+      # analysis results between runs for reasons unrelated to this repository.
+      #
+      # Invoked as `dotnet tool run dotnet-sonarscanner` - the tool's command name is
+      # `dotnet-sonarscanner`, so the `dotnet sonarscanner` shorthand that works for a
+      # GLOBAL install is not the documented form for a local tool. (dotnet-coverage was
+      # installed here too and never invoked - coverage comes from Coverlet MSBuild.)
       - name: SonarScanner Begin
         id: sonar-begin
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: >
-          dotnet sonarscanner begin
+          dotnet tool run dotnet-sonarscanner begin
           /k:"${{ env.SONAR_PROJECT_KEY }}"
           /o:"${{ env.SONAR_ORGANIZATION }}"
           /v:"${{ steps.nbgv-version.outputs.nuget_version }}"
-          /d:sonar.login="$SONAR_TOKEN"
+          /d:sonar.token="$SONAR_TOKEN"
           /d:sonar.host.url="https://sonarcloud.io"
           /d:sonar.projectBaseDir="${{ github.workspace }}"
           /d:sonar.scm.provider=git
           /d:sonar.cs.opencover.reportsPaths=**/CoverageResults/coverage*.opencover.xml
           /d:sonar.coverage.exclusions="**/*.ps1,**/*.Tests/**,**/*.Tests.csproj,samples/**,DocumentationSite/**"
+          /d:sonar.dotnet.excludeTestProjects=true
+          /d:sonar.qualitygate.wait=true
 
       # Build and Test
       - name: Build
@@ -143,12 +151,15 @@ jobs:
         run: dotnet test ${{ env.SOLUTION_PATH }} --verbosity normal --no-build -c Release --logger "trx;LogFileName=TestOutputResults.trx" /p:CollectCoverage=true /p:CoverletOutput=./CoverageResults/ "/p:CoverletOutputFormat=cobertura%2copencover"
 
       # SonarCloud end (runs even after test failures, only if begin succeeded).
-      # Blocking, as above.
+      # Blocking, as above - and now doubly so: `begin` sets sonar.qualitygate.wait=true,
+      # so this step polls SonarCloud until the gate is computed and exits non-zero if it
+      # fails. Without it the job goes green whatever the gate says and enforcement rests
+      # entirely on the branch-protection status check. See issue #26.
       - name: SonarScanner End
         if: always() && steps.sonar-begin.outcome == 'success'
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: dotnet sonarscanner end /d:sonar.login="$SONAR_TOKEN"
+        run: dotnet tool run dotnet-sonarscanner end /d:sonar.token="$SONAR_TOKEN"
 
       # The sample application is a standalone solution outside SOLUTION_PATH: by design it consumes
       # the libraries as NuGet packages, so the main build never compiles it. Build it against the


### PR DESCRIPTION
## **User description**
## Describe your changes

Modernises the SonarCloud analysis configuration in `build-dotnet.yml`. The analysis **method** was already correct — CI-based SonarScanner for .NET is the only method that can analyse C#, since Automatic Analysis reads source without a build and the C# rules need Roslyn compilation output. This PR fixes how that scanner is configured and invoked.

| Change | Why |
|---|---|
| `sonar.login` → `sonar.token` (begin + end) | `sonar.login` is the legacy spelling; current Sonar docs use `sonar.token` exclusively |
| `+ sonar.qualitygate.wait=true` | The job previously went green regardless of the gate. Enforcement rested entirely on the branch-protection status check |
| `dotnet-sonarscanner` pinned to `11.2.1` in `.config/dotnet-tools.json` | The unpinned `dotnet tool install --global` silently picked up new scanner majors, changing analysis results for reasons unrelated to this repo |
| Invoke via `dotnet tool run dotnet-sonarscanner` | See "Design decisions" |
| Removed `Install dotnet-coverage` step | Installed and never invoked — coverage comes from Coverlet MSBuild. Dead step |
| `+ sonar.dotnet.excludeTestProjects=true` | Test projects were excluded from *coverage* but still analysed for issues |

## Design decisions

**Why `dotnet tool run dotnet-sonarscanner` and not `dotnet sonarscanner`.** The tool's `ToolCommandName` is `dotnet-sonarscanner`. As a *global* tool the dotnet CLI strips the `dotnet-` prefix, so `dotnet sonarscanner` works. As a *local* tool the documented invocations are `dotnet tool run dotnet-sonarscanner` or `dotnet dotnet-sonarscanner` — the install output lists exactly those two and not the shorthand.

This is a trap worth naming: on a machine that already has a global scanner installed, `dotnet sonarscanner` appears to work after the switch to a local tool, because the global shim answers. It would then fail on a clean runner. Verified locally that the committed form resolves to the pinned 11.2.1 after `dotnet tool restore`.

**Why `sonar.qualitygate.wait` is on `begin`, not `end`.** SonarScanner for .NET persists `begin` properties into its analysis config and validates `end`-step properties strictly. `begin` is the standard place for all `sonar.*` analysis properties with this scanner; the `end` step performs the actual wait.

**Connected mode is deliberately not in this PR.** `.sonarlint/connectedMode.json` is already added by #25 with byte-identical content. Duplicating it would only create a conflict.

**Not fixed here: the missing baseline.** See below — it needs a merge, not a config change.

## The larger problem this PR does *not* fix

`main` has never been analysed. Verified four ways:

```
git ls-tree -r origin/main --name-only -- .github/workflows
  -> .github/workflows/qodana_code_quality.yml     # build-dotnet.yml is NOT on main
gh run list --branch main                          -> (empty)
get_project_quality_gate_status(main)              -> {"status": "NONE", "conditions": []}
get_component_measures(main)                       -> {"measures": []}
```

`origin/main` is at `e9517a8` (2025-05-21), 38 commits back. Sonar's Clean-as-You-Code model diffs each PR against main's last analysis, so with no reference the *entire codebase* counts as new code — PR #21, a test-only change, reported **243 "New issues"**.

It also silently weakens the gate: on PR #21 only **5 of `Sonar way`'s 6 conditions** were evaluated. `new_coverage < 80` was skipped because every changed line sat in a `sonar.coverage.exclusions` path, and a skipped condition reports as a pass.

**This resolves itself when #11 merges to `main`** and one build runs there. No further code change needed. The remaining manual step is setting the project's New Code definition to **Previous version** in SonarCloud (it pairs with the NBGV-derived `sonar.projectVersion` this workflow already passes).

## Testing

- `dotnet tool restore` succeeds with the new manifest; `dotnet tool run dotnet-sonarscanner` resolves to 11.2.1
- Workflow parses as valid YAML
- `sonar.dotnet.excludeTestProjects` confirmed against the SonarScanner for .NET parameter documentation
- Manifest diff is purely additive (the CLI's `rollForward` churn on `nbgv`/`docfx` was reverted)
- Full verification is the CI run on this PR — the scanner invocation change is exactly the kind that only proves itself on a clean runner

## Risk

`sonar.qualitygate.wait=true` makes a failing gate fail the build. The gate currently passes on PRs (#21 returned `OK`), so this should not block anything immediately. If it does start failing once the baseline lands, that is the gate doing its job rather than a regression in this PR.

## Issue ticket number and link

- Refs #26 — https://github.com/mrploch/ploch-commandline/issues/26
- Related: #12 (CI not running), #24 (clear remaining findings), #25 (connected mode)

Base branch is `#3-spectre-console-initial`, not `main`, matching the existing stack. GitHub will retarget once #11 merges.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests. — n/a, CI configuration; verified by the CI run itself
- [x] Do we need to implement analytics? — no
- [x] Will this be part of a product update? — no, build infrastructure only

## Summary by Sourcery

Make SonarCloud analysis deterministic and enforce its quality gate in the .NET CI workflow.

Bug Fixes:
- Ensure SonarCloud quality-gate failures cause the CI job to fail instead of relying solely on branch protection checks.
- Use current SonarCloud token configuration and exclude test projects from issue analysis.

Enhancements:
- Pin the SonarScanner for .NET version and invoke the restored local tool consistently in CI.
- Remove the unused dotnet-coverage installation step.

CI:
- Modernize the SonarCloud workflow configuration with stable scanner execution and enforced quality-gate waiting.


___

## **CodeAnt-AI Description**
Stabilize SonarCloud analysis and enforce quality gates

### What Changed
- CI now uses a pinned SonarScanner version, so analysis results remain consistent between runs.
- The workflow waits for SonarCloud’s quality gate and fails when the gate does not pass.
- Test projects are excluded from issue analysis while coverage reporting remains unchanged.
- SonarCloud authentication uses the current token configuration, and unused coverage-tool installation was removed.

### Impact
`✅ Failing quality gates block CI`
`✅ Consistent SonarCloud results across runs`
`✅ Fewer irrelevant findings from test projects`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
