### PR TITLE
fix(spectre)!: Fix writer message dispatch (#20) and make AppBuilder configuration additive (#22)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -47,6 +47,10 @@ have been retired.
 - **Breaking:** `IMessageFormatterProcessor.WriteMessage` hands the writer the
   original message and the processor, rather than the formatted text, so a writer
   selected by message type receives a value of that type and formats it itself.
+- **Breaking:** `AppBuilder.ConfigureServices`, `ConfigureHost`, and
+  `ConfigureAppConfiguration` are additive — every delegate is applied, in the
+  order it was added — matching the `IHostBuilder` methods they wrap. They
+  previously kept only the last delegate.
 
 ### Removed
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -44,6 +44,9 @@ have been retired.
   ordinary invocation no longer appears to hang waiting for Enter.
 - **Breaking:** `EnvironmentSettings.Initialize` throws if called after `Current`
   has already been read, instead of silently doing nothing.
+- **Breaking:** `IMessageFormatterProcessor.WriteMessage` hands the writer the
+  original message and the processor, rather than the formatted text, so a writer
+  selected by message type receives a value of that type and formats it itself.
 
 ### Removed
 
@@ -70,3 +73,6 @@ have been retired.
   text contains `[` sequences that Spectre parses as markup.
 - The Serilog error-log sink sat outside its filtered sub-logger, so the "errors"
   file received every event.
+- `IOutput.Write` threw `InvalidCastException` whenever the registered writer for
+  the message expected a type a `string` could not be cast to — writing an
+  `Exception` through `Write` always crashed.

--- a/change-log/20-output-write-message-dispatch.md
+++ b/change-log/20-output-write-message-dispatch.md
@@ -1,0 +1,19 @@
+### Fixed
+
+- `IOutput.Write` threw `InvalidCastException` for any message whose registered
+  writer expects a type a `string` cannot be cast to — writing an `Exception`
+  through `Write` rather than `WriteException` always crashed (#20).
+
+### Changed
+
+- **Breaking:** `IMessageFormatterProcessor.WriteMessage` now hands the writer
+  the original message and the processor itself, instead of the already-formatted
+  text. The writer is selected by the type of the message, so it now receives a
+  value of that type and formats it itself (#20).
+
+  A custom `IMessageWriter<TMessage>` that relied on being given pre-formatted
+  text must format the message itself, using the `IMessageFormatterProcessor`
+  passed to `Write`. As a consequence, `IOutput.Write(anException)` renders the
+  full exception through `ExceptionMessageWriter`, and `IOutput.Write(aCollection)`
+  writes one line per item rather than one line per character of a formatted
+  string.

--- a/change-log/22-appbuilder-additive-configuration.md
+++ b/change-log/22-appbuilder-additive-configuration.md
@@ -12,3 +12,6 @@
   `ConfigureServices` and `ConfigureAppConfiguration` record into the same
   sequence. Code that called one of these methods more than once and relied on
   last-call-wins must now collapse those calls into a single delegate.
+- **Breaking:** those three methods, and both overloads of the two that have
+  them, throw `ArgumentNullException` for a `null` delegate rather than
+  recording it and failing later while the host is built (#22).

--- a/change-log/22-appbuilder-additive-configuration.md
+++ b/change-log/22-appbuilder-additive-configuration.md
@@ -1,0 +1,14 @@
+### Changed
+
+- **Breaking:** `AppBuilder.ConfigureServices`, `AppBuilder.ConfigureHost`, and
+  `AppBuilder.ConfigureAppConfiguration` are additive: every delegate passed to
+  them is applied, in the order it was added. Previously each call replaced the
+  delegate recorded by the previous one, so all but the last was silently
+  discarded (#22).
+
+  This matches `IHostBuilder.ConfigureServices` and
+  `IHostBuilder.ConfigureAppConfiguration`, which `AppBuilder` wraps, and
+  `AppBuilder.AddServicesBundle`, which was already additive. Both overloads of
+  `ConfigureServices` and `ConfigureAppConfiguration` record into the same
+  sequence. Code that called one of these methods more than once and relied on
+  last-call-wins must now collapse those calls into a single delegate.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -296,6 +296,15 @@ table.AddRow(user.Id.ToString(), Markup.Escape(user.Name), Markup.Escape(user.Em
 `MarkupLineInterpolated` escapes its interpolation holes automatically — that is the difference
 between it and building a `Markup` from an interpolated string, which does not.
 
+**`IOutput.Write` dispatches on the type of the message.** A `FormattableString`, a `string` and an
+`IRenderable` are rendered directly; anything else is offered to the registered `IMessageWriter`s,
+and the writer whose message type matches receives the message itself along with the
+`IMessageFormatterProcessor`, so the writer decides how the value is formatted. Writing an
+`Exception` therefore renders the full exception through `ExceptionMessageWriter`, and writing a
+collection produces one line per item. Register your own with
+`services.AddMessageWriter<TMessage, TWriter>()` — and format the message inside `Write` rather than
+expecting to be handed formatted text.
+
 ## 7. Composing a multi-level CLI
 
 Sub-commands are grouped into **branches**. A branch is a verb with no behaviour of its own that

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -96,6 +96,11 @@ Three things happen here that you do not have to write yourself:
 })
 ```
 
+Both overloads are additive, and so are `ConfigureHost` and `ConfigureAppConfiguration`: call them
+as many times as you like and every delegate runs, in the order you added them. That is the same
+behaviour as the `IHostBuilder` methods underneath, so registration can be split across helper
+methods without one call quietly replacing another.
+
 ## 4. Your first command: settings and AppCommand
 
 A command is a pair: a **settings** class describing the command line, and a **command** class

--- a/src/Spectre/CommandLine.Spectre/AppBuilder.cs
+++ b/src/Spectre/CommandLine.Spectre/AppBuilder.cs
@@ -20,10 +20,10 @@ namespace Ploch.CommandLine.Spectre;
 /// </remarks>
 public class AppBuilder(ConsoleAppInfo appInfo, CancellationTokenSource cancellationTokenSource)
 {
+    private readonly List<Action<HostBuilderContext, IConfigurationBuilder>> _appConfigurationConfigurators = [];
+    private readonly List<Action<IHostBuilder>> _hostBuilderConfigurators = [];
+    private readonly List<Action<HostBuilderContext, IServiceCollection>> _serviceCollectionConfigurators = [];
     private readonly HashSet<IServicesBundle> _servicesBundles = new() { new AppServicesBundle() };
-    private Action<HostBuilderContext, IConfigurationBuilder>? _appConfigurationConfigurator;
-    private Action<IHostBuilder>? _hostBuilderConfigurator;
-    private Action<HostBuilderContext, IServiceCollection>? _serviceCollectionConfigurator;
 
     /// <summary>
     ///     Creates a new instance of the <see cref="AppBuilder" /> class with the specified arguments.
@@ -58,7 +58,10 @@ public class AppBuilder(ConsoleAppInfo appInfo, CancellationTokenSource cancella
                                   {
                                       InitializeBundles(services, context);
 
-                                      _serviceCollectionConfigurator?.Invoke(context, services);
+                                      foreach (var servicesConfigurator in _serviceCollectionConfigurators)
+                                      {
+                                          servicesConfigurator(context, services);
+                                      }
 
                                       services.AddSingleton(cancellationTokenSource);
                                   });
@@ -66,11 +69,17 @@ public class AppBuilder(ConsoleAppInfo appInfo, CancellationTokenSource cancella
                                           {
                                               configurationBuilder.AddJsonFile("appsettings.json", optional: true, reloadOnChange: true);
 
-                                              _appConfigurationConfigurator?.Invoke(context, configurationBuilder);
+                                              foreach (var appConfigurationConfigurator in _appConfigurationConfigurators)
+                                              {
+                                                  appConfigurationConfigurator(context, configurationBuilder);
+                                              }
                                           });
 
         // Add services to the container
-        _hostBuilderConfigurator?.Invoke(builder);
+        foreach (var hostBuilderConfigurator in _hostBuilderConfigurators)
+        {
+            hostBuilderConfigurator(builder);
+        }
 
         var registrar = new DependencyInjectionTypeRegistrar(builder);
 
@@ -93,6 +102,10 @@ public class AppBuilder(ConsoleAppInfo appInfo, CancellationTokenSource cancella
     ///     This method simplifies the customization of the application's configuration by allowing direct access to the
     ///     <see cref="IConfigurationBuilder" />. It can be used to add configuration sources, modify existing configurations,
     ///     or apply specific settings without requiring access to the hosting context.
+    ///     <para>
+    ///         Calls accumulate: every delegate passed to either overload is applied, in the order it was added, matching
+    ///         the additive behaviour of <see cref="IHostBuilder.ConfigureAppConfiguration" />.
+    ///     </para>
     /// </remarks>
     [SuppressMessage("ReSharper",
                      "UnusedMember.Global",
@@ -114,13 +127,17 @@ public class AppBuilder(ConsoleAppInfo appInfo, CancellationTokenSource cancella
     ///     This method allows for advanced customization of the application's configuration by enabling
     ///     the use of both the hosting context and the configuration builder. It can be used to add
     ///     configuration sources, modify existing configurations, or apply environment-specific settings.
+    ///     <para>
+    ///         Calls accumulate: every delegate passed to either overload is applied, in the order it was added, matching
+    ///         the additive behaviour of <see cref="IHostBuilder.ConfigureAppConfiguration" />.
+    ///     </para>
     /// </remarks>
     [SuppressMessage("ReSharper",
                      "MemberCanBePrivate.Global",
                      Justification = "This method is a part of the public API and is intended for use by consumers of the AppBuilder class.")]
     public AppBuilder ConfigureAppConfiguration(Action<HostBuilderContext, IConfigurationBuilder> appConfigurationConfigurator)
     {
-        _appConfigurationConfigurator = (context, builder) => { appConfigurationConfigurator?.Invoke(context, builder); };
+        _appConfigurationConfigurators.Add(appConfigurationConfigurator);
 
         return this;
     }
@@ -138,13 +155,14 @@ public class AppBuilder(ConsoleAppInfo appInfo, CancellationTokenSource cancella
     ///     This method allows customization of the application's host builder, enabling the addition
     ///     of services, configuration, and other host-level settings. It integrates with the
     ///     <see cref="Microsoft.Extensions.Hosting" /> framework.
+    ///     <para>Calls accumulate: every delegate is applied to the host builder, in the order it was added.</para>
     /// </remarks>
     [SuppressMessage("ReSharper",
                      "UnusedMember.Global",
                      Justification = "This method is a part of the public API and is intended for use by consumers of the AppBuilder class.")]
     public AppBuilder ConfigureHost(Action<IHostBuilder> configureDelegate)
     {
-        _hostBuilderConfigurator = configureDelegate;
+        _hostBuilderConfigurators.Add(configureDelegate);
 
         return this;
     }
@@ -160,6 +178,10 @@ public class AppBuilder(ConsoleAppInfo appInfo, CancellationTokenSource cancella
     ///     This method allows customization of the application's services by providing a delegate
     ///     that operates on the <see cref="IServiceCollection" />. It is useful for registering
     ///     dependencies and configuring services required by the application.
+    ///     <para>
+    ///         Calls accumulate: every delegate passed to either overload is applied, in the order it was added, matching
+    ///         the additive behaviour of <see cref="IHostBuilder.ConfigureServices" />.
+    ///     </para>
     /// </remarks>
     [SuppressMessage("ReSharper",
                      "UnusedMember.Global",
@@ -180,10 +202,14 @@ public class AppBuilder(ConsoleAppInfo appInfo, CancellationTokenSource cancella
     /// <remarks>
     ///     This method enables the addition or modification of services in the application's dependency injection container.
     ///     It supports advanced configuration scenarios by providing access to the hosting context.
+    ///     <para>
+    ///         Calls accumulate: every delegate passed to either overload is applied, in the order it was added, matching
+    ///         the additive behaviour of <see cref="IHostBuilder.ConfigureServices" />.
+    ///     </para>
     /// </remarks>
     public AppBuilder ConfigureServices(Action<HostBuilderContext, IServiceCollection> servicesConfigurator)
     {
-        _serviceCollectionConfigurator = servicesConfigurator;
+        _serviceCollectionConfigurators.Add(servicesConfigurator);
 
         return this;
     }

--- a/src/Spectre/CommandLine.Spectre/AppBuilder.cs
+++ b/src/Spectre/CommandLine.Spectre/AppBuilder.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Ploch.CommandLine.Spectre.Configuration;
 using Ploch.CommandLine.Spectre.DependencyInjection;
+using Ploch.Common.ArgumentChecking;
 using Ploch.Common.DependencyInjection;
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -98,6 +99,7 @@ public class AppBuilder(ConsoleAppInfo appInfo, CancellationTokenSource cancella
     ///     configuration.
     /// </param>
     /// <returns>The current instance of <see cref="AppBuilder" /> for method chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="appConfigurationConfigurator" /> is <see langword="null" />.</exception>
     /// <remarks>
     ///     This method simplifies the customization of the application's configuration by allowing direct access to the
     ///     <see cref="IConfigurationBuilder" />. It can be used to add configuration sources, modify existing configurations,
@@ -112,6 +114,8 @@ public class AppBuilder(ConsoleAppInfo appInfo, CancellationTokenSource cancella
                      Justification = "This method is a part of the public API and is intended for use by consumers of the AppBuilder class.")]
     public AppBuilder ConfigureAppConfiguration(Action<IConfigurationBuilder> appConfigurationConfigurator)
     {
+        appConfigurationConfigurator.NotNull();
+
         return ConfigureAppConfiguration((_, builder) => appConfigurationConfigurator(builder));
     }
 
@@ -123,6 +127,7 @@ public class AppBuilder(ConsoleAppInfo appInfo, CancellationTokenSource cancella
     ///     <see cref="IConfigurationBuilder" /> for configuring the application's configuration.
     /// </param>
     /// <returns>The current instance of <see cref="AppBuilder" /> for method chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="appConfigurationConfigurator" /> is <see langword="null" />.</exception>
     /// <remarks>
     ///     This method allows for advanced customization of the application's configuration by enabling
     ///     the use of both the hosting context and the configuration builder. It can be used to add
@@ -137,7 +142,7 @@ public class AppBuilder(ConsoleAppInfo appInfo, CancellationTokenSource cancella
                      Justification = "This method is a part of the public API and is intended for use by consumers of the AppBuilder class.")]
     public AppBuilder ConfigureAppConfiguration(Action<HostBuilderContext, IConfigurationBuilder> appConfigurationConfigurator)
     {
-        _appConfigurationConfigurators.Add(appConfigurationConfigurator);
+        _appConfigurationConfigurators.Add(appConfigurationConfigurator.NotNull());
 
         return this;
     }
@@ -151,6 +156,7 @@ public class AppBuilder(ConsoleAppInfo appInfo, CancellationTokenSource cancella
     /// <returns>
     ///     The current instance of <see cref="AppBuilder" /> for method chaining.
     /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configureDelegate" /> is <see langword="null" />.</exception>
     /// <remarks>
     ///     This method allows customization of the application's host builder, enabling the addition
     ///     of services, configuration, and other host-level settings. It integrates with the
@@ -162,7 +168,7 @@ public class AppBuilder(ConsoleAppInfo appInfo, CancellationTokenSource cancella
                      Justification = "This method is a part of the public API and is intended for use by consumers of the AppBuilder class.")]
     public AppBuilder ConfigureHost(Action<IHostBuilder> configureDelegate)
     {
-        _hostBuilderConfigurators.Add(configureDelegate);
+        _hostBuilderConfigurators.Add(configureDelegate.NotNull());
 
         return this;
     }
@@ -174,6 +180,7 @@ public class AppBuilder(ConsoleAppInfo appInfo, CancellationTokenSource cancella
     ///     An action to configure the <see cref="IServiceCollection" /> for dependency injection.
     /// </param>
     /// <returns>The current instance of <see cref="AppBuilder" /> for method chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="servicesConfigurator" /> is <see langword="null" />.</exception>
     /// <remarks>
     ///     This method allows customization of the application's services by providing a delegate
     ///     that operates on the <see cref="IServiceCollection" />. It is useful for registering
@@ -188,6 +195,8 @@ public class AppBuilder(ConsoleAppInfo appInfo, CancellationTokenSource cancella
                      Justification = "This method is a part of the public API and is intended for use by consumers of the AppBuilder class.")]
     public AppBuilder ConfigureServices(Action<IServiceCollection> servicesConfigurator)
     {
+        servicesConfigurator.NotNull();
+
         return ConfigureServices((_, services) => servicesConfigurator(services));
     }
 
@@ -199,6 +208,7 @@ public class AppBuilder(ConsoleAppInfo appInfo, CancellationTokenSource cancella
     ///     <see cref="HostBuilderContext" /> and <see cref="IServiceCollection" /> for configuring services.
     /// </param>
     /// <returns>The current instance of <see cref="AppBuilder" /> to allow method chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="servicesConfigurator" /> is <see langword="null" />.</exception>
     /// <remarks>
     ///     This method enables the addition or modification of services in the application's dependency injection container.
     ///     It supports advanced configuration scenarios by providing access to the hosting context.
@@ -209,7 +219,7 @@ public class AppBuilder(ConsoleAppInfo appInfo, CancellationTokenSource cancella
     /// </remarks>
     public AppBuilder ConfigureServices(Action<HostBuilderContext, IServiceCollection> servicesConfigurator)
     {
-        _serviceCollectionConfigurators.Add(servicesConfigurator);
+        _serviceCollectionConfigurators.Add(servicesConfigurator.NotNull());
 
         return this;
     }

--- a/src/Spectre/CommandLine.Spectre/Output/IMessageFormatterProcessor.cs
+++ b/src/Spectre/CommandLine.Spectre/Output/IMessageFormatterProcessor.cs
@@ -33,5 +33,9 @@ public interface IMessageFormatterProcessor
     ///     <see langword="true" /> if a registered writer handled the message; otherwise <see langword="false" />,
     ///     indicating the caller should fall back to its own rendering.
     /// </returns>
+    /// <remarks>
+    ///     The writer is chosen by the type of <paramref name="message" /> and receives that message unchanged,
+    ///     along with this processor, so that formatting stays the writer's responsibility.
+    /// </remarks>
     bool WriteMessage<TMessage>(TMessage message);
 }

--- a/src/Spectre/CommandLine.Spectre/Output/MessageFormatterProcessor.cs
+++ b/src/Spectre/CommandLine.Spectre/Output/MessageFormatterProcessor.cs
@@ -75,6 +75,13 @@ public class MessageFormatterProcessor(IEnumerable<IMessageFormatter> formatters
     /// <returns>
     ///     <see langword="true" /> if a registered writer handled the message; otherwise <see langword="false" />.
     /// </returns>
+    /// <remarks>
+    ///     The writer is selected by the type of <paramref name="message" /> and is then given that same message,
+    ///     together with this processor so it can format the message itself. Handing the writer the already-formatted
+    ///     text instead would defeat the type-based selection: a writer registered for a type a <see cref="string" />
+    ///     cannot be cast to — <see cref="Exception" />, for example — would fail the cast in
+    ///     <see cref="TypeMessageWriter{TMessage}.Write(object,IMessageFormatterProcessor)" />.
+    /// </remarks>
     public bool WriteMessage<TMessage>(TMessage? message)
     {
         if (message is null)
@@ -88,7 +95,7 @@ public class MessageFormatterProcessor(IEnumerable<IMessageFormatter> formatters
             return false;
         }
 
-        writer.Write(GetMessageText(message));
+        writer.Write(message, this);
 
         return true;
     }

--- a/tests/Spectre/CommandLine.Spectre.Tests/AppBuilderTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/AppBuilderTests.cs
@@ -295,6 +295,42 @@ public sealed class AppBuilderTests : IDisposable
         recorder.SecondConfigurationValue.Should().Be("with-context", "the overload taking the host context records into the same sequence");
     }
 
+    [Fact]
+    public void ConfigureServices_should_reject_a_null_delegate()
+    {
+        var builder = new AppBuilder(new ConsoleAppInfo { Name = "Probe App" }, new CancellationTokenSource());
+
+        var withoutContext = () => builder.ConfigureServices((Action<IServiceCollection>)null!);
+        var withContext = () => builder.ConfigureServices((Action<HostBuilderContext, IServiceCollection>)null!);
+
+        withoutContext.Should()
+                      .Throw<ArgumentNullException>("a delegate that is only stored would otherwise fail much later, while the host is being built")
+                      .WithParameterName("servicesConfigurator");
+        withContext.Should().Throw<ArgumentNullException>().WithParameterName("servicesConfigurator");
+    }
+
+    [Fact]
+    public void ConfigureAppConfiguration_should_reject_a_null_delegate()
+    {
+        var builder = new AppBuilder(new ConsoleAppInfo { Name = "Probe App" }, new CancellationTokenSource());
+
+        var withoutContext = () => builder.ConfigureAppConfiguration((Action<IConfigurationBuilder>)null!);
+        var withContext = () => builder.ConfigureAppConfiguration((Action<HostBuilderContext, IConfigurationBuilder>)null!);
+
+        withoutContext.Should().Throw<ArgumentNullException>().WithParameterName("appConfigurationConfigurator");
+        withContext.Should().Throw<ArgumentNullException>().WithParameterName("appConfigurationConfigurator");
+    }
+
+    [Fact]
+    public void ConfigureHost_should_reject_a_null_delegate()
+    {
+        var builder = new AppBuilder(new ConsoleAppInfo { Name = "Probe App" }, new CancellationTokenSource());
+
+        var act = () => builder.ConfigureHost(null!);
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("configureDelegate");
+    }
+
     /// <summary>
     ///     Builds an application configured by <paramref name="configure" /> and runs a probe command through it.
     ///     The probe reports back through a static slot rather than a registered service, so that the helper's own

--- a/tests/Spectre/CommandLine.Spectre.Tests/AppBuilderTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/AppBuilderTests.cs
@@ -14,13 +14,19 @@ namespace Ploch.CommandLine.Spectre.Tests;
 ///     which only happens once a command actually runs.
 /// </summary>
 /// <remarks>
-///     The three "keep only the last delegate" tests are characterisation tests: they pin the builder's current
-///     last-call-wins behaviour rather than endorsing it, so that changing it to compose the delegates (see issue
-///     #22) is a deliberate decision with a visible failure rather than a silent change.
+///     The three "combine every delegate" tests were characterisation tests pinning the builder's original
+///     last-call-wins behaviour; issue #22 made the three configuration methods additive, matching
+///     <see cref="IHostBuilder" /> and <c>AddServicesBundle</c>, and the tests now pin that instead.
 /// </remarks>
 [Collection(GlobalConsoleState.Name)]
 public sealed class AppBuilderTests : IDisposable
 {
+    /// <summary>Expected marker order for the additive-configuration tests; a field rather than a literal so CA1861 stays quiet.</summary>
+    private static readonly string[] FirstThenSecond = ["first", "second"];
+
+    /// <summary>Expected marker order when the two overloads of the same method are mixed.</summary>
+    private static readonly string[] WithoutThenWithContext = ["without-context", "with-context"];
+
     private readonly IAnsiConsole _originalConsole = AnsiConsole.Console;
     private readonly RecordingConsole _console = new();
 
@@ -201,7 +207,7 @@ public sealed class AppBuilderTests : IDisposable
     }
 
     [Fact]
-    public void ConfigureServices_should_keep_only_the_last_delegate_it_was_given()
+    public void ConfigureServices_should_run_every_delegate_it_was_given()
     {
         var recorder = RunProbeCommand(builder =>
                                        {
@@ -211,13 +217,25 @@ public sealed class AppBuilderTests : IDisposable
 
         recorder.ExitCode.Should().Be(0);
         recorder.MarkerNames.Should()
-                .ContainSingle("the builder stores one delegate, so the earlier registration never runs")
-                .Which.Should()
-                .Be("second");
+                .Equal(FirstThenSecond, "the builder combines the delegates and runs them in the order they were added");
     }
 
     [Fact]
-    public void ConfigureHost_should_keep_only_the_last_delegate_it_was_given()
+    public void ConfigureServices_should_combine_both_overloads_into_the_same_sequence()
+    {
+        var recorder = RunProbeCommand(builder =>
+                                       {
+                                           builder.ConfigureServices(services => services.AddSingleton(new Marker { Name = "without-context" }));
+                                           builder.ConfigureServices((_, services) => services.AddSingleton(new Marker { Name = "with-context" }));
+                                       });
+
+        recorder.ExitCode.Should().Be(0);
+        recorder.MarkerNames.Should()
+                .Equal(WithoutThenWithContext, "the overload taking the host context records into the same sequence");
+    }
+
+    [Fact]
+    public void ConfigureHost_should_run_every_delegate_it_was_given()
     {
         var recorder = RunProbeCommand(builder =>
                                        {
@@ -230,14 +248,11 @@ public sealed class AppBuilderTests : IDisposable
                                        });
 
         recorder.ExitCode.Should().Be(0);
-        recorder.MarkerNames.Should()
-                .ContainSingle("the builder stores one delegate, so the earlier registration never runs")
-                .Which.Should()
-                .Be("second");
+        recorder.MarkerNames.Should().Equal(FirstThenSecond, "the builder combines the delegates and applies them all to the host builder");
     }
 
     [Fact]
-    public void ConfigureAppConfiguration_should_keep_only_the_last_delegate_it_was_given()
+    public void ConfigureAppConfiguration_should_run_every_delegate_it_was_given()
     {
         var recorder = RunProbeCommand(builder =>
                                        {
@@ -255,14 +270,36 @@ public sealed class AppBuilderTests : IDisposable
 
         recorder.ExitCode.Should().Be(0);
         recorder.SecondConfigurationValue.Should().Be("from-the-second-call");
-        recorder.ConfigurationValue.Should().BeNull("the builder stores one delegate, so the earlier configuration source is never added");
+        recorder.ConfigurationValue.Should().Be("from-the-first-call", "the builder combines the delegates, so both configuration sources are added");
+    }
+
+    [Fact]
+    public void ConfigureAppConfiguration_should_combine_both_overloads_into_the_same_sequence()
+    {
+        var recorder = RunProbeCommand(builder =>
+                                       {
+                                           builder.ConfigureAppConfiguration(configuration =>
+                                                                                 configuration.AddInMemoryCollection(new Dictionary<string, string?>
+                                                                                     {
+                                                                                         ["probe:key"] = "without-context"
+                                                                                     }));
+                                           builder.ConfigureAppConfiguration((_, configuration) =>
+                                                                                 configuration.AddInMemoryCollection(new Dictionary<string, string?>
+                                                                                     {
+                                                                                         ["probe:other"] = "with-context"
+                                                                                     }));
+                                       });
+
+        recorder.ExitCode.Should().Be(0);
+        recorder.ConfigurationValue.Should().Be("without-context");
+        recorder.SecondConfigurationValue.Should().Be("with-context", "the overload taking the host context records into the same sequence");
     }
 
     /// <summary>
     ///     Builds an application configured by <paramref name="configure" /> and runs a probe command through it.
-    ///     The probe reports back through a static slot rather than a registered service, because
-    ///     <see cref="AppBuilder.ConfigureServices(Action{IServiceCollection})" /> keeps only the last delegate it was
-    ///     given (issue #22) and the helper must not overwrite whatever the test itself configured.
+    ///     The probe reports back through a static slot rather than a registered service, so that the helper's own
+    ///     registrations stay out of the way of whatever the test configured — the marker assertions count exactly
+    ///     the registrations the test made.
     /// </summary>
     private static ProbeRecorder RunProbeCommand(Action<AppBuilder> configure, CancellationTokenSource? cancellationTokenSource = null)
     {

--- a/tests/Spectre/CommandLine.Spectre.Tests/Configuration/OutputServicesBundleTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/Configuration/OutputServicesBundleTests.cs
@@ -1,7 +1,9 @@
 using Microsoft.Extensions.DependencyInjection;
 using Ploch.CommandLine.Spectre.Configuration;
 using Ploch.CommandLine.Spectre.Output;
+using Ploch.CommandLine.Spectre.Tests.Testing;
 using Ploch.Common.DependencyInjection;
+using Spectre.Console;
 
 namespace Ploch.CommandLine.Spectre.Tests.Configuration;
 
@@ -11,8 +13,25 @@ namespace Ploch.CommandLine.Spectre.Tests.Configuration;
 ///     every <see cref="IConvertible" /> that threw <see cref="NotImplementedException" />, and a write path
 ///     that emitted handled messages twice.
 /// </summary>
-public class OutputServicesBundleTests
+[Collection(GlobalConsoleState.Name)]
+public sealed class OutputServicesBundleTests : IDisposable
 {
+    private readonly IAnsiConsole _originalConsole = AnsiConsole.Console;
+    private readonly RecordingConsole _console = new();
+
+    public OutputServicesBundleTests()
+    {
+        // The bundle captures AnsiConsole.Console when it registers, so the swap has to happen before the provider is built.
+        AnsiConsole.Console = _console.Console;
+    }
+
+    public void Dispose()
+    {
+        AnsiConsole.Console = _originalConsole;
+        _console.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
     [Fact]
     public void Bundle_should_resolve_the_message_formatter_processor()
     {
@@ -61,6 +80,31 @@ public class OutputServicesBundleTests
         var processor = provider.GetRequiredService<IMessageFormatterProcessor>();
 
         processor.WriteMessage("a string").Should().BeTrue("a writer is registered for string");
+    }
+
+    [Fact]
+    public void Write_should_render_an_exception_through_the_registered_exception_writer()
+    {
+        using var provider = BuildProvider();
+        var output = provider.GetRequiredService<IOutput>();
+
+        var act = () => output.Write(new InvalidOperationException("probe failure"));
+
+        act.Should().NotThrow("the writer registered for Exception must be handed the exception, not its formatted text");
+        _console.Output.Should().Contain("probe failure");
+    }
+
+    [Fact]
+    public void Write_should_render_one_line_per_item_for_a_collection()
+    {
+        using var provider = BuildProvider();
+        var output = provider.GetRequiredService<IOutput>();
+
+        output.Write<IEnumerable<string>>(["alpha", "beta"]);
+
+        _console.Output.Should()
+                .Be($"alpha{Environment.NewLine}beta{Environment.NewLine}",
+                    "the writer registered for IEnumerable receives the collection, so it enumerates the items rather than the characters of a formatted string");
     }
 
     [Fact]

--- a/tests/Spectre/CommandLine.Spectre.Tests/Output/MessageFormatterProcessorTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/Output/MessageFormatterProcessorTests.cs
@@ -35,6 +35,33 @@ public class MessageFormatterProcessorTests
     }
 
     [Fact]
+    public void WriteMessage_should_hand_the_original_message_to_the_writer_rather_than_its_formatted_text()
+    {
+        var writer = new RecordingExceptionWriter();
+        var processor = new MessageFormatterProcessor([new ExceptionMessageFormatter()], [writer]);
+        var exception = new InvalidOperationException("probe failure");
+
+        var handled = processor.WriteMessage(exception);
+
+        handled.Should().BeTrue();
+        writer.Written.Should()
+              .ContainSingle()
+              .Which.Should()
+              .BeSameAs(exception, "the writer is chosen by the type of the message, so it has to be given that same message");
+    }
+
+    [Fact]
+    public void WriteMessage_should_supply_itself_as_the_formatter_processor_so_the_writer_can_format_the_message()
+    {
+        var writer = new RecordingExceptionWriter();
+        var processor = new MessageFormatterProcessor([], [writer]);
+
+        processor.WriteMessage(new InvalidOperationException("probe failure"));
+
+        writer.Processors.Should().ContainSingle().Which.Should().BeSameAs(processor, "formatting is the writer's job and it needs the processor to do it");
+    }
+
+    [Fact]
     public void WriteMessage_should_report_false_for_a_null_message()
     {
         var processor = new MessageFormatterProcessor([], [new RecordingStringWriter()]);
@@ -160,6 +187,20 @@ public class MessageFormatterProcessorTests
     {
         public override string GetMessage(string? message, IMessageFormatterProcessor? formatterProcessor = null) =>
             message?.ToUpperInvariant() ?? string.Empty;
+    }
+
+    /// <summary>Records what a writer registered for <see cref="Exception" /> was actually handed.</summary>
+    private sealed class RecordingExceptionWriter : TypeMessageWriter<Exception>
+    {
+        public List<Exception?> Written { get; } = [];
+
+        public List<IMessageFormatterProcessor?> Processors { get; } = [];
+
+        public override void Write(Exception? message, IMessageFormatterProcessor? formatterProcessor = null)
+        {
+            Written.Add(message);
+            Processors.Add(formatterProcessor);
+        }
     }
 
     private sealed class RecordingStringWriter : TypeMessageWriter<string>


### PR DESCRIPTION
## Describe your changes

Fixes two product defects found while raising test coverage in #13/#21. Both are breaking behaviour changes; the packages are unpublished, so no consumer is affected yet.

### #20 — `IOutput.Write(exception)` threw `InvalidCastException`

**Root cause.** `MessageFormatterProcessor.WriteMessage<TMessage>` resolved the writer from the **original** message, then handed that writer the **formatted text**:

```csharp
var writer = GetWriter(message);        // ExceptionMessageWriter, because message is an Exception
writer.Write(GetMessageText(message));  // ...but GetMessageText returns string
```

`TypeMessageWriter<TMessage>.Write(object?)` then does `(TMessage?)message` — casting a `string` to `Exception`. It only appeared to work for the `string`, `FormattableString` and `IEnumerable` writers because a `string` happens to satisfy those casts; for `IEnumerable` it "worked" by enumerating the *characters* of the formatted string, printing one character per line.

**Fix.** The writer is selected by message type, so it is now given that message, together with the processor: `writer.Write(message, this)`. Formatting stays the writer's responsibility, which is what the contract already implied — every writer already receives an `IMessageFormatterProcessor`, and `FormattableStringMessageWriter` / `EnumerableMessageWriter` already use it.

`WriteMessage` still returns `bool`, so `AnsiConsoleMarkupOutput.Write` keeps falling back only when nothing handled the message. The earlier double-write regression is not reintroduced — `Write_should_delegate_to_a_registered_writer_exactly_once` still passes.

**Observable change:** `Write(anException)` now renders the full exception through `ExceptionMessageWriter`; `Write(aCollection)` now writes one line per item instead of one line per character.

### #22 — `AppBuilder` silently discarded all but the last delegate

**Root cause.** `ConfigureServices`, `ConfigureHost` and `ConfigureAppConfiguration` each assigned to a single field, so a second call replaced the first with no exception, warning or log line. The failure surfaced later as an unresolvable dependency inside a command. The wrapped `IHostBuilder` methods are additive and `AddServicesBundle` on the same builder is additive, so the builder contradicted both.

**Fix.** Each method records into a list applied in call order. Both overloads of `ConfigureServices` and `ConfigureAppConfiguration` feed the same sequence.

Making them additive also removed the null-conditional invocation that `ConfigureAppConfiguration` used to apply its single delegate, which had quietly tolerated a null. Rather than restoring the silent tolerance — the exact "your configuration never ran and nothing told you" failure #22 is about — all five entry points now guard with the repository's `NotNull()` extension, so a null fails immediately with an `ArgumentNullException` naming the parameter. (Raised by Sourcery, Codacy and Bito on review; commit 1056b35.)

## Changes

- `MessageFormatterProcessor.WriteMessage` passes the original message and `this` to the resolved writer.
- `AppBuilder` stores `_serviceCollectionConfigurators`, `_hostBuilderConfigurators` and `_appConfigurationConfigurators` as lists and applies each in order, and rejects a null delegate at every entry point.
- XML documentation on `IMessageFormatterProcessor.WriteMessage`, `MessageFormatterProcessor.WriteMessage` and all four `AppBuilder` configuration overloads describes the new contract.
- `change-log/20-output-write-message-dispatch.md` and `change-log/22-appbuilder-additive-configuration.md` added; `RELEASE_NOTES.md` and `docs/GETTING_STARTED.md` updated.

## Design Decisions

- **#20: pass the message, rather than re-resolve the writer from the formatted value.** The issue offered both options. Resolving the writer from the formatted `string` would mean `ExceptionMessageWriter` — and any writer registered for a non-`string` type — could never be selected, making type-based writer registration pointless. Giving the writer the value it was selected for is the only reading under which `IMessageWriter<TMessage>` and the `IMessageFormatterProcessor` parameter both make sense.
- **#22: additive, rather than throwing on a second call or documenting last-call-wins.** Option 1 from the issue: least surprising, and what the wrapped API already does.
- **Lists rather than `Delegate.Combine`.** Equivalent behaviour, but the iteration order is explicit at the call site and each delegate stays visible in a stack trace.
- **Characterisation tests updated, not deleted.** The three "keep only the last delegate" tests existed to make this change deliberate; they now pin the additive behaviour, and the class-level remarks explain the transition.

## Testing

Each fix has a regression test that was written first and confirmed to fail against the unfixed code:

- `WriteMessage_should_hand_the_original_message_to_the_writer_rather_than_its_formatted_text` and `WriteMessage_should_supply_itself_as_the_formatter_processor_so_the_writer_can_format_the_message` — both failed with `InvalidCastException: Unable to cast object of type 'System.String' to type 'System.Exception'`.
- `Write_should_render_an_exception_through_the_registered_exception_writer` — the issue's own reproduction, run against the real `OutputServicesBundle` container; failed with the same `InvalidCastException` through `AnsiConsoleMarkupOutput.Write`.
- `Write_should_render_one_line_per_item_for_a_collection` — failed showing the character-per-line output.
- The three updated `AppBuilder` characterisation tests, plus `ConfigureServices_should_combine_both_overloads_into_the_same_sequence` and `ConfigureAppConfiguration_should_combine_both_overloads_into_the_same_sequence` — all five failed with only the last delegate's effect present.
- `ConfigureServices_should_reject_a_null_delegate`, `ConfigureAppConfiguration_should_reject_a_null_delegate` and `ConfigureHost_should_reject_a_null_delegate` assert both the exception type and the parameter name, on both overloads where there are two.

Verification performed:

- `dotnet build ./Ploch.CommandLine.Spectre.slnx -c Release` — 0 errors, 0 analyser warnings. (The SourceLink "Repository has no commit" warnings seen locally come from building inside a git worktree and are byte-for-byte identical on the unmodified base commit.)
- `dotnet test ./Ploch.CommandLine.Spectre.slnx -c Release` — all pass. `Ploch.CommandLine.Spectre.Tests` 181 → 190.
- Coverage (Coverlet, cobertura + opencover): `Ploch.CommandLine.Spectre` line **99.13%** (was 99.09%), branch 93.66% (unchanged), method 97.19% (unchanged). No regression.
- `dotnet build samples/SampleApp/*.slnx -p:UsePlochProjectReferences=true` — succeeds. The sample was run (`user list`, `file report`) and its output is unchanged: every `Output.Write` call in the sample passes an `IRenderable`, which is handled before the writer pipeline, and exceptions reach the console through `DefaultExceptionHandler` → `IOutput.WriteException`, which this PR does not touch.
- Manual verification of the issue's reproduction against the real container: `IOutput.Write(new InvalidOperationException("probe failure", ...))` now renders the Spectre exception panel including the inner exception instead of throwing, and `IOutput.Write<IEnumerable<string>>(["alpha", "beta"])` prints two lines.

## Breaking Changes

- `IMessageFormatterProcessor.WriteMessage` passes the original message and the processor to the writer instead of the formatted text. A custom `IMessageWriter<TMessage>` that relied on being handed formatted text must format the message itself using the supplied `IMessageFormatterProcessor`.
- `AppBuilder.ConfigureServices`, `ConfigureHost` and `ConfigureAppConfiguration` apply every delegate they are given rather than only the last. Code that called one of them more than once and relied on last-call-wins must collapse those calls into a single delegate.
- Those same methods throw `ArgumentNullException` for a null delegate instead of recording it; `ConfigureAppConfiguration` previously ignored one silently.

## Issue ticket number and link

- Closes #20
- Closes #22

## Related

- Targets `#3-spectre-console-initial` (PR #11) because that branch is not yet merged. Nothing here touches PR #11; retarget to `main` once it merges.
- Follow-up filed as #29: `AppBuilder` applies `ConfigureHost` delegates after `ConfigureServices` regardless of call order. Raised by CodeAnt on this PR; it is a pre-existing characteristic of `ConfigureCommandApp`, not a regression from #22 — the base commit applied its single host delegate at the same point — so it is tracked separately rather than fixed here.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? — n/a
- [x] Will this be part of a product update? — Yes: two breaking bug fixes, in the output pipeline and in the application builder; both have `change-log/` entries feeding the GitHub Release notes.
