### PR TITLE
fix(spectre)!: Escape caller data before wrapping it in a markup tag

### DIFF
--- a/change-log/31-markup-injection-in-output-helpers.md
+++ b/change-log/31-markup-injection-in-output-helpers.md
@@ -1,0 +1,30 @@
+### Fixed
+
+- `IOutput.WriteError`, `WriteErrorLine`, `WriteBold` and `WriteBoldLine` threw
+  `InvalidOperationException` for any message containing a `[` that was not a
+  valid Spectre style tag — `WriteError("Value [archive] is invalid")` crashed
+  with *Could not find color or style 'archive'*. The content is now escaped
+  before the library wraps it in a markup tag (#31).
+
+- A format specifier on an interpolated argument was silently dropped:
+  `$"total: {1234.5:N2}"` rendered as `total: 1234.5` because every argument was
+  stringified before the string was composed, leaving `N2` applied to a `string`.
+  Arguments no formatter claims are now carried through as the original object (#31).
+
+### Changed
+
+- `IOutput.WriteLine<TMessage>` now dispatches through the same path as
+  `IOutput.Write<TMessage>`, so registered `IMessageFormatter` and
+  `IMessageWriter` instances and `IRenderable` messages are honoured on both
+  methods rather than only on `Write` (#31).
+
+  A message that is neither a `string` nor a `FormattableString` and has no
+  registered formatter or writer is now written as plain text instead of being
+  parsed as markup. Callers relying on `WriteLine(someObject)` to render markup
+  from `ToString()` should pass a `FormattableString`, or use
+  `MarkupLineInterpolated`.
+
+Markup written by the caller is unaffected: `Write`, `WriteLine`,
+`MarkupInterpolated` and `MarkupLineInterpolated` still interpret markup in a
+string the caller supplies. Only the tag this library adds on the caller's
+behalf now escapes the content it wraps.

--- a/src/Spectre/CommandLine.Spectre/Output/AnsiConsoleMarkupOutput.cs
+++ b/src/Spectre/CommandLine.Spectre/Output/AnsiConsoleMarkupOutput.cs
@@ -161,24 +161,16 @@ public class AnsiConsoleMarkupOutput(IAnsiConsole console, IMessageFormatterProc
     /// <typeparam name="TMessage">The type of the message to write.</typeparam>
     /// <param name="message">The message to write.</param>
     /// <returns>The current output instance for method chaining.</returns>
+    /// <remarks>
+    ///     Dispatch is delegated to <see cref="Write{TMessage}" /> so that a message reaching this method sees the same
+    ///     renderable handling and the same registered <see cref="IMessageFormatter" /> and <see cref="IMessageWriter" />
+    ///     instances it would through <see cref="Write{TMessage}" />. Rendering the message here instead would make a
+    ///     custom registration take effect on one method and not the other.
+    /// </remarks>
     public IOutput WriteLine<TMessage>(TMessage message)
     {
-        if (message is FormattableString formattableString)
-        {
-            console.MarkupLineInterpolated(formattableString);
+        Write(message);
 
-            return this;
-        }
-
-        if (message is string str)
-        {
-            console.MarkupLine(str);
-
-            return this;
-        }
-
-        console.MarkupLine(message?.ToString() ?? string.Empty);
-
-        return this;
+        return WriteLine();
     }
 }

--- a/src/Spectre/CommandLine.Spectre/Output/MessageFormatterProcessor.cs
+++ b/src/Spectre/CommandLine.Spectre/Output/MessageFormatterProcessor.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
+using Spectre.Console;
 
 namespace Ploch.CommandLine.Spectre.Output;
 
@@ -26,7 +27,7 @@ public class MessageFormatterProcessor(IEnumerable<IMessageFormatter> formatters
         }
 
         var formattedArguments = message.GetArguments()
-                                        .Select(arg =>
+                                        .Select(object? (arg) =>
                                                 {
                                                     if (arg is null)
                                                     {
@@ -35,13 +36,24 @@ public class MessageFormatterProcessor(IEnumerable<IMessageFormatter> formatters
 
                                                     var formatter = GetFormatter(arg);
 
-                                                    return formatter?.GetMessage(arg, this) ?? arg.ToString();
+                                                    // Without a formatter the original object is kept rather than stringified here, so that its
+                                                    // format specifier still applies when the string is composed: pre-rendering it would leave
+                                                    // "{0:N2}" applied to a string, which silently drops the specifier.
+                                                    return formatter is null ? arg : formatter.GetMessage(arg, this);
                                                 })
                                         .ToArray();
 
         var formattedMessage = FormattableStringFactory.Create(message.Format, formattedArguments);
 
-        return markupTag == null ? formattedMessage : FormattableStringFactory.Create($"[{markupTag}]{formattedMessage}[/]");
+        if (markupTag is null)
+        {
+            return formattedMessage;
+        }
+
+        // The tag wraps the format, not the rendered text, so the arguments remain arguments. Spectre escapes the
+        // interpolation holes of a FormattableString when it renders one, which stops a bracket in caller data from
+        // being parsed as a markup tag. Flattening the message into the format string first would forfeit that.
+        return FormattableStringFactory.Create($"[{markupTag}]{message.Format}[/]", formattedArguments);
     }
 
     /// <summary>
@@ -59,12 +71,17 @@ public class MessageFormatterProcessor(IEnumerable<IMessageFormatter> formatters
         }
 
         var messageFormatter = GetFormatter(message);
-        if (messageFormatter == null)
+        var text = messageFormatter is null ? message.ToString() : messageFormatter.GetMessage(message, this);
+
+        if (markupTag is null)
         {
-            return markupTag == null ? message.ToString() : $"[{markupTag}]{message}[/]";
+            return text;
         }
 
-        return markupTag == null ? messageFormatter.GetMessage(message, this) : $"[{markupTag}]{messageFormatter.GetMessage(message, this)}[/]";
+        // The caller asked for a decoration, not for their data to be parsed as markup, so the content is escaped
+        // before the tag is applied. Text the caller passes to IOutput.Write directly is still treated as markup:
+        // that is the contract of a markup output, and only the tag added here is this library's doing.
+        return $"[{markupTag}]{Markup.Escape(text ?? string.Empty)}[/]";
     }
 
     /// <summary>

--- a/tests/Spectre/CommandLine.Spectre.Tests/Output/AnsiConsoleMarkupOutputTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/Output/AnsiConsoleMarkupOutputTests.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using Ploch.CommandLine.Spectre.Output;
 using Ploch.CommandLine.Spectre.Tests.Testing;
 using Spectre.Console;
@@ -276,6 +276,52 @@ public class AnsiConsoleMarkupOutputTests
 
         chained.Should().BeSameAs(output);
         console.Output.Should().Be("ab" + Environment.NewLine + "cd" + Environment.NewLine);
+    }
+
+    [Fact]
+    public void WriteError_should_print_bracketed_data_literally_instead_of_parsing_it_as_markup()
+    {
+        using var console = new RecordingConsole();
+        var output = CreateOutput(console);
+
+        var write = () => output.WriteError("Value [archive] is invalid");
+
+        write.Should().NotThrow("the caller asked for red text, not for their message to be read as a style tag");
+        console.Output.Should().Be("Value [archive] is invalid");
+    }
+
+    [Fact]
+    public void WriteBold_should_print_a_bracketed_path_literally()
+    {
+        using var console = new RecordingConsole();
+        var output = CreateOutput(console);
+
+        output.WriteBold(@"C:\logs\[archive]\x.txt");
+
+        console.Output.Should().Be(@"C:\logs\[archive]\x.txt");
+    }
+
+    [Fact]
+    public void WriteErrorLine_should_print_bracketed_data_literally_and_terminate_the_line()
+    {
+        using var console = new RecordingConsole();
+        var output = CreateOutput(console);
+
+        output.WriteErrorLine("failed on [item]");
+
+        console.Output.Should().Be("failed on [item]" + Environment.NewLine);
+    }
+
+    [Fact]
+    public void WriteLine_should_dispatch_through_the_same_pipeline_as_Write()
+    {
+        using var console = new RecordingConsole();
+        var output = CreateOutput(console);
+
+        output.WriteLine(new UnhandledMessage());
+
+        console.Output.Should().Be(UnhandledMessage.Text + Environment.NewLine,
+                                   "WriteLine and Write must agree on how a message is rendered");
     }
 
     private static AnsiConsoleMarkupOutput CreateOutput(RecordingConsole console) =>

--- a/tests/Spectre/CommandLine.Spectre.Tests/Output/MessageFormatterProcessorTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/Output/MessageFormatterProcessorTests.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using Ploch.CommandLine.Spectre.Output;
 
 namespace Ploch.CommandLine.Spectre.Tests.Output;
@@ -179,7 +179,44 @@ public class MessageFormatterProcessorTests
         var result = processor.GetMessageText(message);
 
         result.Format.Should().Be("{0}-{1}", "the result stays a composite format string rather than being flattened early");
-        result.GetArguments().Should().Equal("1", "2");
+        result.GetArguments().Should().Equal(1, 2);
+    }
+
+    [Fact]
+    public void GetMessageText_should_preserve_the_format_specifier_of_an_unformatted_argument()
+    {
+        var processor = new MessageFormatterProcessor([], []);
+
+        FormattableString message = $"total: {1234.5:N2}";
+
+        var result = processor.GetMessageText(message);
+
+        result.ToString(CultureInfo.InvariantCulture)
+              .Should()
+              .Be("total: 1,234.50", "stringifying the argument first would leave N2 applied to a string, which silently drops it");
+    }
+
+    [Fact]
+    public void GetMessageText_should_keep_the_arguments_of_a_markup_tagged_interpolated_message()
+    {
+        var processor = new MessageFormatterProcessor([], []);
+
+        FormattableString message = $"path: {"[archive]"}";
+
+        var result = processor.GetMessageText(message, "red");
+
+        result.Format.Should().Be("[red]path: {0}[/]", "only the tag is added; the message keeps its holes");
+        result.GetArguments().Should().Equal("[archive]");
+    }
+
+    [Fact]
+    public void GetMessageText_should_escape_a_tagged_message_that_contains_markup_characters()
+    {
+        var processor = new MessageFormatterProcessor([], []);
+
+        var result = processor.GetMessageText("Value [archive] is invalid", "red");
+
+        result.Should().Be("[red]Value [[archive]] is invalid[/]", "the caller asked for a colour, not for their data to be parsed as markup");
     }
 
     /// <summary>A formatter that visibly transforms its input, so a test can prove the formatter was actually applied.</summary>


### PR DESCRIPTION
## **User description**
## Summary

`IOutput` pushed arbitrary caller data through Spectre's markup parser, so any message containing a `[` that was not a valid style tag threw at runtime. For a console library whose `WriteError` exists to print exception text — text that routinely contains brackets — that is a v1 blocker.

Closes #31.

## The defect, reproduced

Against `#3-spectre-console-initial` @ `5934877`:

```csharp
output.WriteError("Value [archive] is invalid");
```

```
System.InvalidOperationException: Could not find color or style 'archive'.
   at Spectre.Console.StyleParser.Parse(String text)
   at Ploch.CommandLine.Spectre.Output.AnsiConsoleMarkupOutput.Write[TMessage](TMessage, IFormatProvider)
      in src/Spectre/CommandLine.Spectre/Output/AnsiConsoleMarkupOutput.cs:line 63
```

`WriteBold(@"C:\logs\[archive]\x.txt")` failed identically.

## Changes

**`MessageFormatterProcessor.GetMessageText<TMessage>`** — escapes the content with `Markup.Escape` before wrapping it in the tag.

**`MessageFormatterProcessor.GetMessageText(FormattableString)`** — two fixes in one place:

- Arguments no formatter claims are carried through as the **original object** rather than pre-stringified. Stringifying first left `N2` applied to a `string`, so `$"total: {1234.5:N2}"` rendered as `total: 1234.5`.
- The markup tag now wraps the **format string**, not the rendered text. Previously `FormattableStringFactory.Create($"[{tag}]{formattedMessage}[/]")` flattened the message into the format slot of a zero-argument `FormattableString`, discarding Spectre's automatic escaping of interpolation holes.

**`AnsiConsoleMarkupOutput.WriteLine<TMessage>`** — delegates to `Write<TMessage>` instead of rendering the message itself, so registered formatters, writers and `IRenderable` messages behave the same on both methods.

## Design decisions

**Markup the caller writes is still honoured.** `Write(string)`, `WriteLine(string)`, `MarkupInterpolated` and `MarkupLineInterpolated` continue to interpret markup — that is the documented contract of a class called `AnsiConsoleMarkupOutput`, and `Write_should_render_a_plain_string_as_markup` pins it. The boundary drawn here is: markup is honoured where the **caller** wrote it, and escaped where **this library** adds the tag on their behalf.

A consequence worth stating plainly: `output.WriteLine(someUntrustedString)` can still throw, because that call opts into markup by contract. Whether `IOutput` should also offer an explicitly-escaping write is left open in #31 rather than decided quietly here.

**Escaping wins over formatter-emitted markup.** A custom `IMessageFormatter` that deliberately returns `"[green]OK[/]"` will now have that shown literally when a tag is applied. Serving both needs an opt-in on the formatter contract; safe-by-default is the right v1 choice, and the opt-in can follow if a real formatter needs it. Noted in #31.

**Rejected: `console.Write` instead of `console.Markup` for strings** — Codacy's literal suggestion. It would break the documented markup contract and the existing tests, and it fixes the symptom at the wrong layer: the bug is the *unescaped tag wrapping*, not the markup parsing.

## Testing

Four new tests in `AnsiConsoleMarkupOutputTests` (`WriteError`, `WriteBold`, `WriteErrorLine` with bracketed data; `WriteLine` pipeline parity) and three in `MessageFormatterProcessorTests` (format-specifier preservation, argument retention under a tag, escaping under a tag).

```
Passed!  - Failed: 0, Passed: 197, Skipped: 0, Total: 197
dotnet build -c Release  ->  0 Warning(s), 0 Error(s)
```

**One existing assertion changed.** `GetMessageText_should_keep_the_interpolated_arguments_separate_from_the_format_string` asserted the arguments were the strings `"1"` and `"2"`. That stringification is precisely the defect being fixed; the test's stated intent — "the result stays a composite format string rather than being flattened early" — is preserved and now more strongly held.

## Breaking changes

`IOutput.WriteLine(message)` writes a message that is neither a `string` nor a `FormattableString`, and that has no registered formatter or writer, as **plain text** rather than parsing its `ToString()` result as markup. Pass a `FormattableString` or use `MarkupLineInterpolated` to render markup from such a message.

Recorded in `change-log/31-markup-injection-in-output-helpers.md`.

## Related

- Closes #31
- Follows #20 and #22 (PR #28) — same review pass on PR #11
- Resolves three Codacy threads on #11: `AnsiConsoleMarkupOutput.cs:180` (HIGH), `MessageFormatterProcessor.cs:68`, `MessageFormatterProcessor.cs:43`

## Summary by Sourcery

Prevent output helper failures and formatting inconsistencies by safely wrapping caller data in markup and unifying message rendering across write methods.

Bug Fixes:
- Escape caller-provided content when output helpers wrap it in Spectre markup, preventing bracketed text such as paths and exception messages from being parsed as style tags.
- Preserve interpolated argument objects and format specifiers when applying markup tags.

Enhancements:
- Route generic WriteLine calls through the same formatting, writer, and renderable pipeline as Write, with unsupported messages rendered as plain text.

Documentation:
- Document the markup-injection fixes, formatting behavior, WriteLine dispatch changes, and the resulting compatibility guidance.

Tests:
- Add coverage for bracketed output, interpolated format preservation, markup-tagged arguments, escaping, and WriteLine pipeline parity.


___

## **CodeAnt-AI Description**
Prevent output helpers from misreading caller text as markup

### What Changed
- Error and bold output now print bracketed text and paths literally instead of treating them as style tags and throwing an exception.
- Interpolated messages retain numeric format specifiers and safely handle bracketed argument values when decorated with error or bold styling.
- `WriteLine` now uses the same formatting, writer, and renderable handling as `Write`; unsupported objects are written as plain text.
- Direct markup supplied by callers continues to be interpreted as markup.

### Impact
`✅ Fewer output crashes for bracketed messages`
`✅ Correct numeric formatting in interpolated output`
`✅ Consistent formatting between Write and WriteLine`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
