### PR TITLE
fix(spectre): Let a message writer own its own line termination

### DIFF
--- a/change-log/31-markup-injection-in-output-helpers.md
+++ b/change-log/31-markup-injection-in-output-helpers.md
@@ -24,12 +24,23 @@
   from `ToString()` should pass a `FormattableString`, or use
   `MarkupLineInterpolated`.
 
-- `IMessageWriter` implementations now own the line termination of what they
-  render: `IOutput.WriteLine` adds no terminator of its own to a message a
-  writer handled. A writer whose output is line-oriented must emit its own
-  trailing newline; one whose output is inline must not. The built-in writers
-  already follow this, so `WriteLine(aCollection)` no longer leaves a blank
-  line after the last item and an empty collection no longer renders one (#31).
+- **Breaking:** `IMessageWriter` gains `WritesLineTerminator`, a property a
+  writer uses to declare that it already ends its output with a line break. It
+  defaults to `false`, so `IOutput.WriteLine` keeps appending a terminator for a
+  writer that renders inline. `EnumerableMessageWriter` and
+  `ExceptionMessageWriter` declare `true`, so `WriteLine(aCollection)` no longer
+  leaves a blank line after the last item and an empty collection no longer
+  renders one (#31).
+
+  A custom writer that emits its own trailing newline should override
+  `WritesLineTerminator` to return `true`. One that renders inline needs no
+  change.
+
+- **Breaking:** `IMessageFormatterProcessor.WriteMessage` returns the
+  `IMessageWriter` that rendered the message, or `null` if none could handle it,
+  instead of a `bool`. Callers need the writer itself in order to consult
+  `WritesLineTerminator`. Replace `if (processor.WriteMessage(x))` with
+  `if (processor.WriteMessage(x) is not null)` (#31).
 
 Markup written by the caller is unaffected: `Write`, `WriteLine`,
 `MarkupInterpolated` and `MarkupLineInterpolated` still interpret markup in a

--- a/change-log/31-markup-injection-in-output-helpers.md
+++ b/change-log/31-markup-injection-in-output-helpers.md
@@ -24,6 +24,13 @@
   from `ToString()` should pass a `FormattableString`, or use
   `MarkupLineInterpolated`.
 
+- `IMessageWriter` implementations now own the line termination of what they
+  render: `IOutput.WriteLine` adds no terminator of its own to a message a
+  writer handled. A writer whose output is line-oriented must emit its own
+  trailing newline; one whose output is inline must not. The built-in writers
+  already follow this, so `WriteLine(aCollection)` no longer leaves a blank
+  line after the last item and an empty collection no longer renders one (#31).
+
 Markup written by the caller is unaffected: `Write`, `WriteLine`,
 `MarkupInterpolated` and `MarkupLineInterpolated` still interpret markup in a
 string the caller supplies. Only the tag this library adds on the caller's

--- a/src/Spectre/CommandLine.Spectre/Output/AnsiConsoleMarkupOutput.cs
+++ b/src/Spectre/CommandLine.Spectre/Output/AnsiConsoleMarkupOutput.cs
@@ -51,33 +51,7 @@ public class AnsiConsoleMarkupOutput(IAnsiConsole console, IMessageFormatterProc
     /// <returns>The current output instance for method chaining.</returns>
     public IOutput Write<TMessage>(TMessage message, IFormatProvider? format = null)
     {
-        if (message is FormattableString formattableString)
-        {
-            console.MarkupInterpolated(format ?? CultureInfo.CurrentCulture, formattableString);
-
-            return this;
-        }
-
-        if (message is string str)
-        {
-            console.Markup(str);
-
-            return this;
-        }
-
-        if (message is IRenderable renderable)
-        {
-            console.Write(renderable);
-
-            return this;
-        }
-
-        if (formatterProcessor.WriteMessage(message))
-        {
-            return this;
-        }
-
-        console.Write(message?.ToString() ?? string.Empty);
+        WriteCore(message, format);
 
         return this;
     }
@@ -166,11 +140,59 @@ public class AnsiConsoleMarkupOutput(IAnsiConsole console, IMessageFormatterProc
     ///     renderable handling and the same registered <see cref="IMessageFormatter" /> and <see cref="IMessageWriter" />
     ///     instances it would through <see cref="Write{TMessage}" />. Rendering the message here instead would make a
     ///     custom registration take effect on one method and not the other.
+    ///     <para>
+    ///         When a registered <see cref="IMessageWriter" /> renders the message it also owns the line termination,
+    ///         and no further terminator is written. See <see cref="IMessageWriter.Write" /> for that contract.
+    ///     </para>
     /// </remarks>
     public IOutput WriteLine<TMessage>(TMessage message)
     {
-        Write(message);
+        // A registered writer owns the line termination of what it renders, so no terminator is added on top of one.
+        // EnumerableMessageWriter, for example, already emits a line per item; appending here would leave a blank
+        // line after the last one, and would turn an empty collection into a stray blank line.
+        return WriteCore(message) ? this : WriteLine();
+    }
 
-        return WriteLine();
+    /// <summary>
+    ///     Renders a message and reports whether a registered <see cref="IMessageWriter" /> was the one that rendered it.
+    /// </summary>
+    /// <typeparam name="TMessage">The type of the message to write.</typeparam>
+    /// <param name="message">The message to write.</param>
+    /// <param name="format">The format provider to use for formatting, or null to use the current culture.</param>
+    /// <returns>
+    ///     <see langword="true" /> if a registered <see cref="IMessageWriter" /> rendered the message and therefore owns
+    ///     its line termination; otherwise <see langword="false" />.
+    /// </returns>
+    private bool WriteCore<TMessage>(TMessage message, IFormatProvider? format = null)
+    {
+        if (message is FormattableString formattableString)
+        {
+            console.MarkupInterpolated(format ?? CultureInfo.CurrentCulture, formattableString);
+
+            return false;
+        }
+
+        if (message is string str)
+        {
+            console.Markup(str);
+
+            return false;
+        }
+
+        if (message is IRenderable renderable)
+        {
+            console.Write(renderable);
+
+            return false;
+        }
+
+        if (formatterProcessor.WriteMessage(message))
+        {
+            return true;
+        }
+
+        console.Write(message?.ToString() ?? string.Empty);
+
+        return false;
     }
 }

--- a/src/Spectre/CommandLine.Spectre/Output/AnsiConsoleMarkupOutput.cs
+++ b/src/Spectre/CommandLine.Spectre/Output/AnsiConsoleMarkupOutput.cs
@@ -141,16 +141,24 @@ public class AnsiConsoleMarkupOutput(IAnsiConsole console, IMessageFormatterProc
     ///     instances it would through <see cref="Write{TMessage}" />. Rendering the message here instead would make a
     ///     custom registration take effect on one method and not the other.
     ///     <para>
-    ///         When a registered <see cref="IMessageWriter" /> renders the message it also owns the line termination,
-    ///         and no further terminator is written. See <see cref="IMessageWriter.Write" /> for that contract.
+    ///         A terminator is still written unless the writer that rendered the message declares
+    ///         <see cref="IMessageWriter.WritesLineTerminator" />, so a writer that renders inline keeps this method's
+    ///         "followed by a line break" contract.
     ///     </para>
     /// </remarks>
     public IOutput WriteLine<TMessage>(TMessage message)
     {
-        // A registered writer owns the line termination of what it renders, so no terminator is added on top of one.
-        // EnumerableMessageWriter, for example, already emits a line per item; appending here would leave a blank
-        // line after the last one, and would turn an empty collection into a stray blank line.
-        return WriteCore(message) ? this : WriteLine();
+        var writer = WriteCore(message);
+
+        // Only a writer that declares it already emitted a terminator suppresses this one. Suppressing it for every
+        // writer-handled message would silently drop the line break for a writer that renders inline, which is the
+        // one thing WriteLine promises. EnumerableMessageWriter declares true because it writes a line per item.
+        if (writer is { WritesLineTerminator: true })
+        {
+            return this;
+        }
+
+        return WriteLine();
     }
 
     /// <summary>
@@ -160,39 +168,40 @@ public class AnsiConsoleMarkupOutput(IAnsiConsole console, IMessageFormatterProc
     /// <param name="message">The message to write.</param>
     /// <param name="format">The format provider to use for formatting, or null to use the current culture.</param>
     /// <returns>
-    ///     <see langword="true" /> if a registered <see cref="IMessageWriter" /> rendered the message and therefore owns
-    ///     its line termination; otherwise <see langword="false" />.
+    ///     The registered <see cref="IMessageWriter" /> that rendered the message, or <see langword="null" /> when the
+    ///     message was rendered directly by this class.
     /// </returns>
-    private bool WriteCore<TMessage>(TMessage message, IFormatProvider? format = null)
+    private IMessageWriter? WriteCore<TMessage>(TMessage message, IFormatProvider? format = null)
     {
         if (message is FormattableString formattableString)
         {
             console.MarkupInterpolated(format ?? CultureInfo.CurrentCulture, formattableString);
 
-            return false;
+            return null;
         }
 
         if (message is string str)
         {
             console.Markup(str);
 
-            return false;
+            return null;
         }
 
         if (message is IRenderable renderable)
         {
             console.Write(renderable);
 
-            return false;
+            return null;
         }
 
-        if (formatterProcessor.WriteMessage(message))
+        var writer = formatterProcessor.WriteMessage(message);
+        if (writer is not null)
         {
-            return true;
+            return writer;
         }
 
         console.Write(message?.ToString() ?? string.Empty);
 
-        return false;
+        return null;
     }
 }

--- a/src/Spectre/CommandLine.Spectre/Output/EnumerableMessageWriter.cs
+++ b/src/Spectre/CommandLine.Spectre/Output/EnumerableMessageWriter.cs
@@ -10,6 +10,12 @@ namespace Ploch.CommandLine.Spectre.Output;
 public class EnumerableMessageWriter(IAnsiConsole output) : TypeMessageWriter<IEnumerable>
 {
     /// <summary>
+    ///     Gets a value indicating whether this writer ends its output with a line terminator.
+    /// </summary>
+    /// <remarks>Always <see langword="true" />: every item is written on its own line.</remarks>
+    public override bool WritesLineTerminator => true;
+
+    /// <summary>
     ///     Writes each item in the enumerable collection to the output.
     /// </summary>
     /// <param name="enumerable">The enumerable collection to write. If null, a "No items to display" message is shown.</param>

--- a/src/Spectre/CommandLine.Spectre/Output/ExceptionMessageWriter.cs
+++ b/src/Spectre/CommandLine.Spectre/Output/ExceptionMessageWriter.cs
@@ -9,6 +9,12 @@ namespace Ploch.CommandLine.Spectre.Output;
 public class ExceptionMessageWriter(IAnsiConsole output) : TypeMessageWriter<Exception>
 {
     /// <summary>
+    ///     Gets a value indicating whether this writer ends its output with a line terminator.
+    /// </summary>
+    /// <remarks>Always <see langword="true" />: Spectre's exception rendering ends with a line break.</remarks>
+    public override bool WritesLineTerminator => true;
+
+    /// <summary>
     ///     Writes an exception message to the configured output.
     /// </summary>
     /// <param name="message">The exception to be written. Can be null.</param>

--- a/src/Spectre/CommandLine.Spectre/Output/IMessageFormatterProcessor.cs
+++ b/src/Spectre/CommandLine.Spectre/Output/IMessageFormatterProcessor.cs
@@ -30,12 +30,13 @@ public interface IMessageFormatterProcessor
     /// <typeparam name="TMessage">The type of the message to write.</typeparam>
     /// <param name="message">The message to write.</param>
     /// <returns>
-    ///     <see langword="true" /> if a registered writer handled the message; otherwise <see langword="false" />,
-    ///     indicating the caller should fall back to its own rendering.
+    ///     The registered writer that rendered the message, or <see langword="null" /> if none could handle it,
+    ///     indicating the caller should fall back to its own rendering. The writer is returned rather than a simple
+    ///     flag so the caller can consult <see cref="IMessageWriter.WritesLineTerminator" />.
     /// </returns>
     /// <remarks>
     ///     The writer is chosen by the type of <paramref name="message" /> and receives that message unchanged,
     ///     along with this processor, so that formatting stays the writer's responsibility.
     /// </remarks>
-    bool WriteMessage<TMessage>(TMessage message);
+    IMessageWriter? WriteMessage<TMessage>(TMessage message);
 }

--- a/src/Spectre/CommandLine.Spectre/Output/IMessageWriter.cs
+++ b/src/Spectre/CommandLine.Spectre/Output/IMessageWriter.cs
@@ -6,14 +6,25 @@
 public interface IMessageWriter : IMessageHandler
 {
     /// <summary>
+    ///     Gets a value indicating whether this writer ends its own output with a line terminator.
+    /// </summary>
+    /// <remarks>
+    ///     <see cref="IOutput.WriteLine{TMessage}" /> appends a terminator to a message this writer handled unless
+    ///     this is <see langword="true" />. The default is <see langword="false" />, which keeps
+    ///     <see cref="IOutput.WriteLine{TMessage}" />'s "followed by a line break" contract intact for a writer that
+    ///     renders inline. A writer that emits its own trailing newline -- one that writes a line per item, for
+    ///     example -- must report <see langword="true" /> so that a blank line is not added after it.
+    /// </remarks>
+    bool WritesLineTerminator => false;
+
+    /// <summary>
     ///     Writes a message to the output with optional formatting.
     /// </summary>
     /// <param name="message">The message to write. Can be null.</param>
     /// <param name="formatterProcessor">Optional formatter processor to apply custom formatting to the message.</param>
     /// <remarks>
-    ///     An implementation owns the line termination of what it renders. <see cref="IOutput.WriteLine{TMessage}" />
-    ///     adds no terminator of its own to a message a writer handled, so a writer whose output is line-oriented
-    ///     must emit its own trailing newline and one whose output is inline must not.
+    ///     A writer that emits its own trailing newline must report <see cref="WritesLineTerminator" /> as
+    ///     <see langword="true" />, so that <see cref="IOutput.WriteLine{TMessage}" /> does not add a second one.
     /// </remarks>
     void Write(object? message, IMessageFormatterProcessor? formatterProcessor = null);
 }
@@ -42,9 +53,8 @@ public interface IMessageWriter<in TMessage> : IMessageWriter where TMessage : a
     /// <param name="message">The message to write. Can be null.</param>
     /// <param name="formatterProcessor">Optional formatter processor to apply custom formatting to the message.</param>
     /// <remarks>
-    ///     An implementation owns the line termination of what it renders. <see cref="IOutput.WriteLine{TMessage}" />
-    ///     adds no terminator of its own to a message a writer handled, so a writer whose output is line-oriented
-    ///     must emit its own trailing newline and one whose output is inline must not.
+    ///     A writer that emits its own trailing newline must report <see cref="IMessageWriter.WritesLineTerminator" />
+    ///     as <see langword="true" />, so that <see cref="IOutput.WriteLine{TMessage}" /> does not add a second one.
     /// </remarks>
     void Write(TMessage? message, IMessageFormatterProcessor? formatterProcessor = null);
 }

--- a/src/Spectre/CommandLine.Spectre/Output/IMessageWriter.cs
+++ b/src/Spectre/CommandLine.Spectre/Output/IMessageWriter.cs
@@ -1,4 +1,4 @@
-namespace Ploch.CommandLine.Spectre.Output;
+﻿namespace Ploch.CommandLine.Spectre.Output;
 
 /// <summary>
 ///     Defines a writer for outputting messages with optional formatting.
@@ -10,6 +10,11 @@ public interface IMessageWriter : IMessageHandler
     /// </summary>
     /// <param name="message">The message to write. Can be null.</param>
     /// <param name="formatterProcessor">Optional formatter processor to apply custom formatting to the message.</param>
+    /// <remarks>
+    ///     An implementation owns the line termination of what it renders. <see cref="IOutput.WriteLine{TMessage}" />
+    ///     adds no terminator of its own to a message a writer handled, so a writer whose output is line-oriented
+    ///     must emit its own trailing newline and one whose output is inline must not.
+    /// </remarks>
     void Write(object? message, IMessageFormatterProcessor? formatterProcessor = null);
 }
 
@@ -36,5 +41,10 @@ public interface IMessageWriter<in TMessage> : IMessageWriter where TMessage : a
     /// </summary>
     /// <param name="message">The message to write. Can be null.</param>
     /// <param name="formatterProcessor">Optional formatter processor to apply custom formatting to the message.</param>
+    /// <remarks>
+    ///     An implementation owns the line termination of what it renders. <see cref="IOutput.WriteLine{TMessage}" />
+    ///     adds no terminator of its own to a message a writer handled, so a writer whose output is line-oriented
+    ///     must emit its own trailing newline and one whose output is inline must not.
+    /// </remarks>
     void Write(TMessage? message, IMessageFormatterProcessor? formatterProcessor = null);
 }

--- a/src/Spectre/CommandLine.Spectre/Output/MessageFormatterProcessor.cs
+++ b/src/Spectre/CommandLine.Spectre/Output/MessageFormatterProcessor.cs
@@ -43,11 +43,9 @@ public class MessageFormatterProcessor(IEnumerable<IMessageFormatter> formatters
                                                 })
                                         .ToArray();
 
-        var formattedMessage = FormattableStringFactory.Create(message.Format, formattedArguments);
-
         if (markupTag is null)
         {
-            return formattedMessage;
+            return FormattableStringFactory.Create(message.Format, formattedArguments);
         }
 
         // The tag wraps the format, not the rendered text, so the arguments remain arguments. Spectre escapes the

--- a/src/Spectre/CommandLine.Spectre/Output/MessageFormatterProcessor.cs
+++ b/src/Spectre/CommandLine.Spectre/Output/MessageFormatterProcessor.cs
@@ -88,7 +88,7 @@ public class MessageFormatterProcessor(IEnumerable<IMessageFormatter> formatters
     /// <typeparam name="TMessage">The type of the message to write.</typeparam>
     /// <param name="message">The message to write. If null, no action is taken.</param>
     /// <returns>
-    ///     <see langword="true" /> if a registered writer handled the message; otherwise <see langword="false" />.
+    ///     The registered writer that rendered the message, or <see langword="null" /> if none could handle it.
     /// </returns>
     /// <remarks>
     ///     The writer is selected by the type of <paramref name="message" /> and is then given that same message,
@@ -97,22 +97,18 @@ public class MessageFormatterProcessor(IEnumerable<IMessageFormatter> formatters
     ///     cannot be cast to — <see cref="Exception" />, for example — would fail the cast in
     ///     <see cref="TypeMessageWriter{TMessage}.Write(object,IMessageFormatterProcessor)" />.
     /// </remarks>
-    public bool WriteMessage<TMessage>(TMessage? message)
+    public IMessageWriter? WriteMessage<TMessage>(TMessage? message)
     {
         if (message is null)
         {
-            return false;
+            return null;
         }
 
         var writer = GetWriter(message);
-        if (writer is null)
-        {
-            return false;
-        }
 
-        writer.Write(message, this);
+        writer?.Write(message, this);
 
-        return true;
+        return writer;
     }
 
     /// <summary>

--- a/src/Spectre/CommandLine.Spectre/Output/TypeMessageWriter.cs
+++ b/src/Spectre/CommandLine.Spectre/Output/TypeMessageWriter.cs
@@ -7,6 +7,17 @@
 public abstract class TypeMessageWriter<TMessage> : TypeMessageHandler<TMessage>, IMessageWriter<TMessage>
 {
     /// <summary>
+    ///     Gets a value indicating whether this writer ends its output with a line terminator.
+    /// </summary>
+    /// <remarks>
+    ///     Declared here, on the type that implements <see cref="IMessageWriter{TMessage}" />, rather than left to the
+    ///     interface's default implementation. Interface mapping is fixed at this class, so a property introduced by a
+    ///     derived writer would not map to the interface member and a caller holding an <see cref="IMessageWriter" />
+    ///     would still see the default. Overriding a virtual declared here maps correctly.
+    /// </remarks>
+    public virtual bool WritesLineTerminator => false;
+
+    /// <summary>
     ///     Writes a message of type <typeparamref name="TMessage" />.
     /// </summary>
     /// <param name="message">The message to write.</param>

--- a/tests/Spectre/CommandLine.Spectre.Tests/Configuration/OutputServicesBundleTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/Configuration/OutputServicesBundleTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Ploch.CommandLine.Spectre.Configuration;
 using Ploch.CommandLine.Spectre.Output;
 using Ploch.CommandLine.Spectre.Tests.Testing;
@@ -74,12 +74,12 @@ public sealed class OutputServicesBundleTests : IDisposable
     }
 
     [Fact]
-    public void WriteMessage_should_report_that_a_string_was_handled()
+    public void WriteMessage_should_report_the_writer_that_handled_a_string()
     {
         using var provider = BuildProvider();
         var processor = provider.GetRequiredService<IMessageFormatterProcessor>();
 
-        processor.WriteMessage("a string").Should().BeTrue("a writer is registered for string");
+        processor.WriteMessage("a string").Should().NotBeNull("a writer is registered for string");
     }
 
     [Fact]

--- a/tests/Spectre/CommandLine.Spectre.Tests/Output/AnsiConsoleMarkupOutputTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/Output/AnsiConsoleMarkupOutputTests.cs
@@ -324,6 +324,45 @@ public class AnsiConsoleMarkupOutputTests
                                    "WriteLine and Write must agree on how a message is rendered");
     }
 
+    [Fact]
+    public void WriteLine_should_not_append_a_terminator_after_a_writer_that_owns_line_termination()
+    {
+        using var console = new RecordingConsole();
+        var output = CreateOutputWithEnumerableWriter(console);
+
+        output.WriteLine(new[] { "a", "b" });
+
+        console.Output
+               .Should()
+               .Be("a" + Environment.NewLine + "b" + Environment.NewLine,
+                   "EnumerableMessageWriter already writes a line per item, so a further terminator would leave a blank line");
+    }
+
+    [Fact]
+    public void WriteLine_should_write_nothing_for_an_empty_collection_handled_by_a_writer()
+    {
+        using var console = new RecordingConsole();
+        var output = CreateOutputWithEnumerableWriter(console);
+
+        output.WriteLine(Array.Empty<string>());
+
+        console.Output.Should().BeEmpty("an empty collection has no lines, so it must not produce a stray blank one");
+    }
+
+    [Fact]
+    public void Write_should_still_delegate_a_collection_to_the_registered_writer()
+    {
+        using var console = new RecordingConsole();
+        var output = CreateOutputWithEnumerableWriter(console);
+
+        output.Write(new[] { "a", "b" });
+
+        console.Output.Should().Be("a" + Environment.NewLine + "b" + Environment.NewLine);
+    }
+
+    private static AnsiConsoleMarkupOutput CreateOutputWithEnumerableWriter(RecordingConsole console) =>
+        new(console.Console, new MessageFormatterProcessor([], [new EnumerableMessageWriter(console.Console)]));
+
     private static AnsiConsoleMarkupOutput CreateOutput(RecordingConsole console) =>
         new(console.Console, new MessageFormatterProcessor([new StringMessageFormatter()], []));
 

--- a/tests/Spectre/CommandLine.Spectre.Tests/Output/AnsiConsoleMarkupOutputTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/Output/AnsiConsoleMarkupOutputTests.cs
@@ -360,6 +360,44 @@ public class AnsiConsoleMarkupOutputTests
         console.Output.Should().Be("a" + Environment.NewLine + "b" + Environment.NewLine);
     }
 
+    [Fact]
+    public void WriteLine_should_still_terminate_the_line_for_a_writer_that_renders_inline()
+    {
+        using var console = new RecordingConsole();
+        var output = new AnsiConsoleMarkupOutput(console.Console,
+                                                 new MessageFormatterProcessor([], [new InlineProbeWriter(console.Console)]));
+
+        output.WriteLine(new ProbeMessage());
+
+        console.Output
+               .Should()
+               .Be(InlineProbeWriter.Rendered + Environment.NewLine,
+                   "a writer that does not terminate its own output must not cost WriteLine its line break");
+    }
+
+    [Fact]
+    public void Write_should_not_add_a_terminator_for_a_writer_that_renders_inline()
+    {
+        using var console = new RecordingConsole();
+        var output = new AnsiConsoleMarkupOutput(console.Console,
+                                                 new MessageFormatterProcessor([], [new InlineProbeWriter(console.Console)]));
+
+        output.Write(new ProbeMessage());
+
+        console.Output.Should().Be(InlineProbeWriter.Rendered);
+    }
+
+    /// <summary>A message type no built-in writer claims, so the probe writer below is the one that handles it.</summary>
+    private sealed class ProbeMessage;
+
+    /// <summary>A writer that renders inline and therefore leaves the line terminator to <see cref="IOutput.WriteLine{TMessage}" />.</summary>
+    private sealed class InlineProbeWriter(IAnsiConsole console) : TypeMessageWriter<ProbeMessage>
+    {
+        public const string Rendered = "inline-probe";
+
+        public override void Write(ProbeMessage? message, IMessageFormatterProcessor? formatterProcessor = null) => console.Write(Rendered);
+    }
+
     private static AnsiConsoleMarkupOutput CreateOutputWithEnumerableWriter(RecordingConsole console) =>
         new(console.Console, new MessageFormatterProcessor([], [new EnumerableMessageWriter(console.Console)]));
 
@@ -400,6 +438,6 @@ public class AnsiConsoleMarkupOutputTests
             return message?.ToString();
         }
 
-        public bool WriteMessage<TMessage>(TMessage message) => false;
+        public IMessageWriter? WriteMessage<TMessage>(TMessage message) => null;
     }
 }

--- a/tests/Spectre/CommandLine.Spectre.Tests/Output/AnsiConsoleMarkupOutputTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/Output/AnsiConsoleMarkupOutputTests.cs
@@ -397,7 +397,7 @@ public class AnsiConsoleMarkupOutputTests
     private sealed class InlineProbeWriter(IAnsiConsole console) : TypeMessageWriter<ProbeMessage>
     {
         public override void Write(ProbeMessage? message, IMessageFormatterProcessor? formatterProcessor = null) =>
-            console.Write(message?.Text ?? string.Empty);
+            console.Write(formatterProcessor?.GetMessageText(message?.Text) ?? message?.Text ?? string.Empty);
     }
 
     private static AnsiConsoleMarkupOutput CreateOutputWithEnumerableWriter(RecordingConsole console) =>
@@ -421,10 +421,15 @@ public class AnsiConsoleMarkupOutputTests
         public override void Write(System.Collections.IEnumerable? message, IMessageFormatterProcessor? formatterProcessor = null) => WriteCount++;
     }
 
-    /// <summary>Records the markup tags the output adapter asks for, which is otherwise invisible once rendered.</summary>
+    /// <summary>
+    ///     Records the markup tags the output adapter asks for, and the messages it offers to the writer pipeline —
+    ///     both invisible once rendered.
+    /// </summary>
     private sealed class RecordingFormatterProcessor : IMessageFormatterProcessor
     {
         public List<string?> RequestedTags { get; } = [];
+
+        public List<object?> MessagesOfferedToWriters { get; } = [];
 
         public FormattableString GetMessageText(FormattableString? message, string? markupTag = null)
         {
@@ -440,7 +445,12 @@ public class AnsiConsoleMarkupOutputTests
             return message?.ToString();
         }
 
-        /// <summary>Handles nothing, so callers always fall back to their own rendering.</summary>
-        public IMessageWriter? WriteMessage<TMessage>(TMessage _) => null;
+        /// <summary>Records the offer and handles nothing, so callers always fall back to their own rendering.</summary>
+        public IMessageWriter? WriteMessage<TMessage>(TMessage message)
+        {
+            MessagesOfferedToWriters.Add(message);
+
+            return null;
+        }
     }
 }

--- a/tests/Spectre/CommandLine.Spectre.Tests/Output/AnsiConsoleMarkupOutputTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/Output/AnsiConsoleMarkupOutputTests.cs
@@ -367,11 +367,11 @@ public class AnsiConsoleMarkupOutputTests
         var output = new AnsiConsoleMarkupOutput(console.Console,
                                                  new MessageFormatterProcessor([], [new InlineProbeWriter(console.Console)]));
 
-        output.WriteLine(new ProbeMessage());
+        output.WriteLine(new ProbeMessage("inline-probe"));
 
         console.Output
                .Should()
-               .Be(InlineProbeWriter.Rendered + Environment.NewLine,
+               .Be("inline-probe" + Environment.NewLine,
                    "a writer that does not terminate its own output must not cost WriteLine its line break");
     }
 
@@ -382,20 +382,22 @@ public class AnsiConsoleMarkupOutputTests
         var output = new AnsiConsoleMarkupOutput(console.Console,
                                                  new MessageFormatterProcessor([], [new InlineProbeWriter(console.Console)]));
 
-        output.Write(new ProbeMessage());
+        output.Write(new ProbeMessage("inline-probe"));
 
-        console.Output.Should().Be(InlineProbeWriter.Rendered);
+        console.Output.Should().Be("inline-probe");
     }
 
     /// <summary>A message type no built-in writer claims, so the probe writer below is the one that handles it.</summary>
-    private sealed class ProbeMessage;
+    private sealed class ProbeMessage(string text)
+    {
+        public string Text { get; } = text;
+    }
 
     /// <summary>A writer that renders inline and therefore leaves the line terminator to <see cref="IOutput.WriteLine{TMessage}" />.</summary>
     private sealed class InlineProbeWriter(IAnsiConsole console) : TypeMessageWriter<ProbeMessage>
     {
-        public const string Rendered = "inline-probe";
-
-        public override void Write(ProbeMessage? message, IMessageFormatterProcessor? formatterProcessor = null) => console.Write(Rendered);
+        public override void Write(ProbeMessage? message, IMessageFormatterProcessor? formatterProcessor = null) =>
+            console.Write(message?.Text ?? string.Empty);
     }
 
     private static AnsiConsoleMarkupOutput CreateOutputWithEnumerableWriter(RecordingConsole console) =>
@@ -438,6 +440,7 @@ public class AnsiConsoleMarkupOutputTests
             return message?.ToString();
         }
 
-        public IMessageWriter? WriteMessage<TMessage>(TMessage message) => null;
+        /// <summary>Handles nothing, so callers always fall back to their own rendering.</summary>
+        public IMessageWriter? WriteMessage<TMessage>(TMessage _) => null;
     }
 }

--- a/tests/Spectre/CommandLine.Spectre.Tests/Output/MessageFormatterProcessorTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/Output/MessageFormatterProcessorTests.cs
@@ -11,26 +11,26 @@ namespace Ploch.CommandLine.Spectre.Tests.Output;
 public class MessageFormatterProcessorTests
 {
     [Fact]
-    public void WriteMessage_should_report_true_when_a_registered_writer_handles_the_message()
+    public void WriteMessage_should_report_the_writer_that_handled_the_message()
     {
         var writer = new RecordingStringWriter();
         var processor = new MessageFormatterProcessor([], [writer]);
 
         var handled = processor.WriteMessage("hello");
 
-        handled.Should().BeTrue();
+        handled.Should().NotBeNull();
         writer.Written.Should().ContainSingle().Which.Should().Be("hello");
     }
 
     [Fact]
-    public void WriteMessage_should_report_false_when_no_writer_can_handle_the_message()
+    public void WriteMessage_should_report_no_writer_when_none_can_handle_the_message()
     {
         var writer = new RecordingStringWriter();
         var processor = new MessageFormatterProcessor([], [writer]);
 
         var handled = processor.WriteMessage(42);
 
-        handled.Should().BeFalse();
+        handled.Should().BeNull();
         writer.Written.Should().BeEmpty("a writer that cannot handle the message must not be invoked");
     }
 
@@ -43,7 +43,7 @@ public class MessageFormatterProcessorTests
 
         var handled = processor.WriteMessage(exception);
 
-        handled.Should().BeTrue();
+        handled.Should().NotBeNull();
         writer.Written.Should()
               .ContainSingle()
               .Which.Should()
@@ -62,11 +62,11 @@ public class MessageFormatterProcessorTests
     }
 
     [Fact]
-    public void WriteMessage_should_report_false_for_a_null_message()
+    public void WriteMessage_should_report_no_writer_for_a_null_message()
     {
         var processor = new MessageFormatterProcessor([], [new RecordingStringWriter()]);
 
-        processor.WriteMessage<string>(null).Should().BeFalse();
+        processor.WriteMessage<string>(null).Should().BeNull();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Follow-up to #35, which made `IOutput.WriteLine` delegate to `Write` so registered formatters and writers take effect on both methods — then appended a line terminator unconditionally.

**I merged #35 before reading its review threads.** Three reviewers had flagged the regression and I checked only the thread *count*. This PR fixes what that let through, and then fixes a second flaw that the review of *this* PR exposed.

Refs #31.

## Round 1 — the trailing blank line

`EnumerableMessageWriter` writes one line per item, so an unconditional terminator on top of it produced:

- `WriteLine(new[] { "a", "b" })` → `a`, `b`, then a **blank line**.
- `WriteLine(Array.Empty<string>())` → a **stray blank line** for a collection with nothing in it.

Reproduced before fixing. Raised by Sourcery, Codex and CodeAnt.

## Round 2 — the contract contradicted itself

My first fix suppressed the terminator for **every** writer-handled message, while documenting that an inline writer *may* omit its trailing newline. Those cannot both hold: a custom writer rendering inline would make `WriteLine(message)` behave exactly like `Write(message)`, dropping the one thing `WriteLine` promises. Sourcery, Codex and Codacy all caught it on this PR.

The fix is the one they pointed at — let the writer declare it:

```csharp
public interface IMessageWriter : IMessageHandler
{
    bool WritesLineTerminator => false;   // safe default: WriteLine keeps terminating
}
```

```csharp
public IOutput WriteLine<TMessage>(TMessage message)
{
    var writer = WriteCore(message);

    if (writer is { WritesLineTerminator: true })
    {
        return this;
    }

    return WriteLine();
}
```

`EnumerableMessageWriter` and `ExceptionMessageWriter` declare `true`. Everything else — including every custom writer that does nothing — keeps its line break.

### A C# trap worth recording

Declaring `WritesLineTerminator` directly on the two concrete writers compiled, but would have been **silently wrong**. Interface mapping is fixed at `TypeMessageWriter<TMessage>`, the type that declares `IMessageWriter<TMessage>`; a property introduced by a derived class does not map to the interface member, so a caller holding an `IMessageWriter` would still have read the default `false` and the blank-line bug would have returned.

It is now `virtual` on `TypeMessageWriter` and `override` in the writers. `CA1822`/`S2325` firing on the first shape is what exposed it — the analyser was right for a reason it could not state.

## Codacy threads from #35

**Accepted:** the untagged `FormattableString` is no longer constructed when a markup tag is supplied and it would be discarded.

**Declined** — escaping `message.Format` in the tagged interpolated path:

1. It would break the interpolation contract. Spectre's `MarkupInterpolated` escapes the *holes* and treats the *literal* as markup. The rule here is the same: **data is escaped, developer-written literal text is markup.** Escaping the format would make `$"[bold]{x}[/]"` render its tags literally.
2. The crash path it guards is unreachable from the decorating helpers. `WriteError<TMessage>` binds statically to the *generic* overload — an unconstrained type parameter cannot bind to the `FormattableString` one — and that overload escapes the whole value. Verified: `output.WriteError<FormattableString>($"Value [archive] at {7}")` does not throw.

## Breaking changes

- `IMessageFormatterProcessor.WriteMessage` returns `IMessageWriter?` instead of `bool`. Replace `if (processor.WriteMessage(x))` with `if (processor.WriteMessage(x) is not null)`.
- A custom `IMessageWriter` that emits its own trailing newline must override `WritesLineTerminator` to return `true`. One that renders inline needs no change.

Recorded in `change-log/31-markup-injection-in-output-helpers.md`.

## Testing

Five new tests: no trailing terminator after a writer-handled collection, nothing at all for an empty collection, `Write` still delegating to the writer, and — for round 2 — an inline writer still getting its line break from `WriteLine` and none from `Write`.

```
Passed!  - Failed: 0, Passed: 202, Skipped: 0, Total: 202   (Ploch.CommandLine.Spectre.Tests)
All 8 test assemblies pass.
dotnet build -c Release  ->  0 Warning(s), 0 Error(s)
```

## Related

- Refs #31
- Follows #35, which introduced the regression

## Summary by Sourcery

Fix message output line termination by allowing writers to declare ownership of trailing line breaks while preserving consistent `Write` and `WriteLine` behavior.

Bug Fixes:
- Prevent `WriteLine` from adding extra or stray line terminators when a message writer already owns line termination.
- Preserve `WriteLine`'s line-break contract for custom writers that render messages inline.
- Avoid constructing discarded untagged interpolated messages when a markup tag is supplied.

Enhancements:
- Return the handling `IMessageWriter` from message processing so output can account for writer-owned line termination.
- Add an explicit writer contract for declaring whether output already ends with a line terminator.

Documentation:
- Document the breaking changes for `IMessageWriter` line-termination ownership and the `WriteMessage` return type.

Tests:
- Add coverage for collection, empty collection, inline writer, and write-versus-writeline termination behavior.