### PR TITLE
chore(solution): Scope Codacy to project deliverables

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -23,8 +23,17 @@ engines:
   #
   # Test doubles implement IOutput and IMessageFormatter in full and necessarily leave most
   # parameters unused, so S1172 fires on the signature rather than on a defect.
+  #
+  # A per-engine exclude_paths list replaces the global one for that engine rather than adding to
+  # it, so the global entries are repeated here. Keep the two lists in step.
   sonarcsharp:
     exclude_paths:
       - "tests/**"
+      - ".agents/**"
+      - ".claude/**"
+      - ".cursor/**"
+      - "AGENTS.md"
+      - "CLAUDE.md"
+      - "GEMINI.md"
   markdownlint:
     line_length: 120

--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,7 +1,30 @@
 ---
+# Paths excluded from every Codacy engine.
+#
+# These hold AI-assistant configuration, not project deliverables: `.agents/`, `.claude/` and
+# `.cursor/` are three near-identical mirrors of the same skills and rules, and the three root
+# files are the per-assistant entry points into them. Markdown-lint and agent-linter findings on
+# them measure the tooling, not the library, and they arrive in triplicate.
+#
+# Markdown that ships to consumers is deliberately NOT excluded and stays under review:
+# README.md, RELEASE_NOTES.md, docs/, change-log/, .github/ and every src/**/README.md.
+exclude_paths:
+  - ".agents/**"
+  - ".claude/**"
+  - ".cursor/**"
+  - "AGENTS.md"
+  - "CLAUDE.md"
+  - "GEMINI.md"
+
 engines:
-  sonarscharp:
+  # The engine key was previously misspelled "sonarscharp" and pointed at "src/**Tests/**", a path
+  # that matches nothing because test projects live under tests/. Both were silently no-ops, which
+  # is why analyser findings on test doubles reached the pull request at all.
+  #
+  # Test doubles implement IOutput and IMessageFormatter in full and necessarily leave most
+  # parameters unused, so S1172 fires on the signature rather than on a defect.
+  sonarcsharp:
     exclude_paths:
-      - "src/**Tests/**"
+      - "tests/**"
   markdownlint:
     line_length: 120

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,7 @@
 ## Issue ticket number and link
 
 ## Checklist before requesting a review
+
 - [ ] I have performed a self-review of my code
 - [ ] If it is a core feature, I have added thorough tests.
 - [ ] Do we need to implement analytics?

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ploch CommandLine Applications
 
-# Overview
+## Overview
 
 **Ploch CommandLine Applications** is an opinionated library for building console applications in .NET Core.
 It builds on top of the [Spectre.Console](https://spectreconsole.net/) library, providing a few additional features:

--- a/src/Spectre/CommandLine.Spectre/README.md
+++ b/src/Spectre/CommandLine.Spectre/README.md
@@ -25,8 +25,7 @@ It includes:
 
 ## Getting Started
 
-TODO, GitHub Issue: [Ploch.CommandLine.Spectre Getting Started documentation #4
-](https://github.com/mrploch/ploch-commandline/issues/4)
+TODO, GitHub Issue: [Ploch.CommandLine.Spectre Getting Started documentation #4](https://github.com/mrploch/ploch-commandline/issues/4)
 
 ## Dependency Injection
 
@@ -39,5 +38,4 @@ This project provides following services bundles:
 
 - `AppServicesBundle` - registers services required for the app to run
 - `OutputServicesBundle` - registers services required for output formatting
-
 

--- a/tests/Spectre/CommandLine.Spectre.Tests/Output/AnsiConsoleMarkupOutputTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/Output/AnsiConsoleMarkupOutputTests.cs
@@ -13,6 +13,9 @@ namespace Ploch.CommandLine.Spectre.Tests.Output;
 /// </summary>
 public class AnsiConsoleMarkupOutputTests
 {
+    /// <summary>Two items, hoisted so the collection tests do not allocate a constant array at each call site (CA1861).</summary>
+    private static readonly string[] TwoItems = ["a", "b"];
+
     [Fact]
     public void Write_should_render_a_plain_string_as_markup()
     {
@@ -330,7 +333,7 @@ public class AnsiConsoleMarkupOutputTests
         using var console = new RecordingConsole();
         var output = CreateOutputWithEnumerableWriter(console);
 
-        output.WriteLine(new[] { "a", "b" });
+        output.WriteLine(TwoItems);
 
         console.Output
                .Should()
@@ -355,7 +358,7 @@ public class AnsiConsoleMarkupOutputTests
         using var console = new RecordingConsole();
         var output = CreateOutputWithEnumerableWriter(console);
 
-        output.Write(new[] { "a", "b" });
+        output.Write(TwoItems);
 
         console.Output.Should().Be("a" + Environment.NewLine + "b" + Environment.NewLine);
     }
@@ -387,6 +390,12 @@ public class AnsiConsoleMarkupOutputTests
         console.Output.Should().Be("inline-probe");
     }
 
+    private static AnsiConsoleMarkupOutput CreateOutputWithEnumerableWriter(RecordingConsole console) =>
+        new(console.Console, new MessageFormatterProcessor([], [new EnumerableMessageWriter(console.Console)]));
+
+    private static AnsiConsoleMarkupOutput CreateOutput(RecordingConsole console) =>
+        new(console.Console, new MessageFormatterProcessor([new StringMessageFormatter()], []));
+
     /// <summary>A message type no built-in writer claims, so the probe writer below is the one that handles it.</summary>
     private sealed class ProbeMessage(string text)
     {
@@ -399,12 +408,6 @@ public class AnsiConsoleMarkupOutputTests
         public override void Write(ProbeMessage? message, IMessageFormatterProcessor? formatterProcessor = null) =>
             console.Write(formatterProcessor?.GetMessageText(message?.Text) ?? message?.Text ?? string.Empty);
     }
-
-    private static AnsiConsoleMarkupOutput CreateOutputWithEnumerableWriter(RecordingConsole console) =>
-        new(console.Console, new MessageFormatterProcessor([], [new EnumerableMessageWriter(console.Console)]));
-
-    private static AnsiConsoleMarkupOutput CreateOutput(RecordingConsole console) =>
-        new(console.Console, new MessageFormatterProcessor([new StringMessageFormatter()], []));
 
     private sealed class UnhandledMessage
     {


### PR DESCRIPTION
## **User description**
## Summary

PR #11 introduces the whole repository, so every file counts as new code and Codacy reports **412 new findings** on it. None are defects in library logic — but the check is red, and the gate treats that as blocking.

Closes #38.

## What the 412 findings actually are

| Group | Count |
|---|---|
| Markdown-lint / agent-lint on `.agents/`, `.claude/`, `.cursor/`, `AGENTS.md`, `CLAUDE.md`, `GEMINI.md` | ~341 |
| `SonarCSharp_S2360` — optional parameters (`src/`) | ~34 |
| `SonarCSharp_S1172` — unused parameter (`tests/` test doubles) | ~29 |
| `SonarCSharp_S3459`, `SonarCSharp_S2339` | 8 |
| Markdown in files that actually ship | 5 |

The markdown group is dominated by `MD032` ("lists should be surrounded by blank lines", 179 of them) plus Codacy's `Agentlinter` rules judging the agent instructions for undefined terms and vague phrasing.

## The existing config never worked

`.codacy.yml` has been broken since the initial commit (`37ae9bc`), in two independent ways:

```yaml
engines:
  sonarscharp:              # misspelled; the engine key is `sonarcsharp`
    exclude_paths:
      - "src/**Tests/**"    # matches nothing; test projects live under tests/
```

Either mistake alone would have disabled it. That is why analyser findings on test doubles reach pull requests at all. Both are corrected here, restoring the exclusion the original was clearly trying to express.

## Changes

**Excluded the AI-assistant configuration from every engine.** `.agents/`, `.claude/` and `.cursor/` are three near-identical mirrors of the same skills; the three root files are the per-assistant entry points into them. Findings there measure the tooling, not the library, and arrive in triplicate.

**Markdown that ships stays under review** — `README.md`, `RELEASE_NOTES.md`, `docs/`, `change-log/`, `.github/` and every `src/**/README.md`. Deliberate: those are read by consumers.

**Fixed the five findings in shipping markdown** rather than excluding them:

- `README.md:3` — a second top-level heading (`# Overview` → `## Overview`).
- `.github/pull_request_template.md:5-6` — a list with no blank line above it.
- `src/Spectre/CommandLine.Spectre/README.md:28,43` — a newline inside link text, and a doubled blank line.

**Scoped SonarC# away from `tests/`.** Test doubles implement `IOutput` and `IMessageFormatter` in full and necessarily leave most parameters unused, so `S1172` fires on the signature rather than on a defect. This is blunter than a per-rule exclusion — it also stops SonarC# finding genuine problems in test code — but it is what the original config intended and per-rule scoping is not expressible in `.codacy.yml`.

## Still needs a click in the Codacy UI

Two patterns cannot be configured from this file. Recorded with evidence in #38:

- **`SonarCSharp_S2360`** (~34 in `src/`) — "use the overloading mechanism instead of the optional parameters". `IMessageFormatterProcessor? formatterProcessor = null` is a pervasive, deliberate API idiom across `IOutput`, `IMessageFormatter`, `IMessageWriter`, `TypeMessageFormatter`, `TypeMessageWriter` and their implementations. Honouring the rule means duplicating every interface method as a pair of overloads.
- **`SonarCSharp_S2339`** (3 in `EnvironmentVariableNames.cs`) — "change this constant to a static readonly field". Already declined on #11 with evidence: the BCL uses `const` for the same shape (`MediaTypeNames.Application.Json` is `IsLiteral=True`) and `static readonly` only where the value varies by platform (`Path.DirectorySeparatorChar`); and the change does not compile, because `PauseBeforeExit` is a `const` interpolation over the other two, giving `CS0133`.

Until those two are switched off, Codacy on #11 will still report ~37 issues.

## Also here: three analyser errors from #37

Out of this PR's stated scope, but included because the base branch is currently red and this is the open pull request against it.

Qodana has failed on `#3-spectre-console-initial` from the moment #37 merged, and on every branch cut from it since. Its build surfaced three errors in the tests #37 added:

```
AnsiConsoleMarkupOutputTests.cs(403,44): error SA1201: A method should not follow a class
AnsiConsoleMarkupOutputTests.cs(333,26): error CA1861: Prefer 'static readonly' fields over constant array arguments
AnsiConsoleMarkupOutputTests.cs(358,22): error CA1861: (as above)
```

The two probe classes were inserted above the private helper methods, and `new[] { "a", "b" }` was passed as an argument at two call sites. The classes now sit with the other nested types below the methods, and the array is a `static readonly` field.

**Why they got through.** The verification for #37 was run in Release only. These three analysers fail the build in **Debug** — the configuration CI builds — and not in Release. A clean Debug build reproduces all three; a clean Release build reports `0/0`. That is a gap in how I verified, not a flaky check.

## Testing

The markdown and `.codacy.yml` changes are text-only. The analyser fix is verified in both configurations, and in Debug specifically because that is what CI builds:

```
dotnet build Ploch.CommandLine.Spectre.slnx -c Debug   --no-incremental  ->  0 Warning(s), 0 Error(s)
dotnet build Ploch.CommandLine.Spectre.slnx -c Release --no-incremental  ->  0 Warning(s), 0 Error(s)
dotnet test  Ploch.CommandLine.Spectre.slnx -c Debug                     ->  202 passed, 0 failed
```

## Related

- Closes #38
- Unblocks the Codacy condition of the completion gate on #11

## Summary by Sourcery

Scope Codacy analysis to project deliverables, correct analyzer exclusions, and resolve the resulting documentation and test analyzer findings.

Bug Fixes:
- Correct Codacy's C# engine configuration and exclude test projects so analyzer findings from test doubles no longer block reviews.
- Fix analyzer errors in the test suite so Debug and Release builds complete successfully.

Enhancements:
- Scope Codacy analysis to project deliverables while excluding AI-assistant configuration files.
- Keep shipped Markdown under review and resolve its heading, list-spacing, link-formatting, and whitespace findings.

Tests:
- Update analyzer-sensitive test code and verify clean Debug and Release builds with all tests passing.


___

## **CodeAnt-AI Description**
Scope code analysis to project deliverables and fix reported documentation issues

### What Changed
- Codacy now excludes AI-assistant configuration files while continuing to check documentation shipped with the project
- C# analysis now correctly applies the test-project exclusion, preventing findings from test doubles from blocking reviews
- Fixed heading structure, checklist spacing, link formatting, and trailing whitespace in project documentation

### Impact
`✅ Fewer irrelevant Codacy findings`
`✅ Test-only analyzer warnings no longer block reviews`
`✅ Cleaner published documentation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

