### PR TITLE
fix(solution): Stop committing the ContextStream API key

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "contextstream": {
       "headers": {
-        "X-ContextStream-API-Key": "cbiq_tALPHr-a-gn2sOlSRo25ESHbCuy0Wk2QH8zFwO7Vjv8",
+        "X-ContextStream-API-Key": "${env:CONTEXTSTREAM_API_KEY}",
         "X-ContextStream-Auto-Hide-Integrations": "true",
         "X-ContextStream-Consolidated": "true",
         "X-ContextStream-Context-Pack-Enabled": "true",


### PR DESCRIPTION
## **User description**
## Summary

`.cursor/mcp.json` carried a live 48-character credential as a literal under the `X-ContextStream-API-Key` header. Committed in `a8fdb29` and **pushed to this public repository**, so it has been readable by anyone since. It **is now on `main`**: merging #11 carried it to the default branch of this public repository as of `d73d3d9`. This removes it from the branch going forward; it does not remove it from `main`'s history, and merging this PR does not either.

Found by GitHub Copilot's PR reviewer on #11.

Closes #40.

## Change

```diff
-        "X-ContextStream-API-Key": "<48-character literal>",
+        "X-ContextStream-API-Key": "${env:CONTEXTSTREAM_API_KEY}",
```

Nothing else in the file changed; it still parses as JSON. Anyone using this configuration now sets `CONTEXTSTREAM_API_KEY` in their environment.

## Status changed since this PR was opened

When this was written the credential was confined to the #11 branch. **#11 has since been merged**, so the
literal is now in `.cursor/mcp.json` on `main` — the default branch of a public repository — and in the
history of every clone, fork and mirror taken since. That moves rotation from "outstanding" to the only
control that actually revokes anything; removing the value cannot.

## What this does not do

**It does not undo the exposure.** The value is still in the branch's commit history and has been public for as long as the branch has been pushed.

**Rotating the key in ContextStream is the only action that actually revokes access, and it is still outstanding.** This PR stops the value travelling any further; it does not make the old one safe.

## Why nothing caught it earlier

Secret scanning is disabled on this repository, so GitHub's push protection — the control that would have blocked this at push time rather than surfacing it at review — never ran. Worth enabling org-wide.

Note that #39 excluded `.cursor/**` from Codacy. Trivy does secret detection and is enabled here, so that exclusion now also removes this directory from Trivy's reach. Narrowing the exclusion to markdown only, or carving `.cursor/` back in for Trivy specifically, is worth doing — tracked on #40.

## Related

- Closes #40
- Second credential found in this repository. The first, a plaintext nuget.org API key in `37ae9bc` (2024-10-16), is also still awaiting rotation.

## Summary by Sourcery

Bug Fixes:
- Replace the committed ContextStream API key with an environment-variable reference to prevent further credential exposure.


___

## **CodeAnt-AI Description**
Stop exposing the ContextStream API key in the repository

### What Changed
- The ContextStream configuration now reads the API key from the `CONTEXTSTREAM_API_KEY` environment variable instead of storing the credential directly
- Users must provide the environment variable to authenticate ContextStream

### Impact
`✅ Prevents new credential exposure`
`✅ Keeps API keys out of committed configuration`
`✅ Preserves ContextStream configuration behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated API key configuration to read from an environment variable instead of storing the key directly in configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
