### PR TITLE
fix(spectre)!: Connect the cancellation token to the running command

### DIFF
--- a/DocumentationSite/index.md
+++ b/DocumentationSite/index.md
@@ -108,11 +108,11 @@ usual hosting extension points are available:
 - `Dispose` — release the `Console.CancelKeyPress` handler and the `CancellationTokenSource` that
   `Create` installed. A builder constructed directly with your own source owns neither and leaves
   both alone.
+- `AddServicesBundle<TBundle>` — register a `ServicesBundle` from `Ploch.Common.DependencyInjection`.
 
 The token behind that source is handed to Spectre and reaches every command. The first Ctrl+C cancels
 it cooperatively; a second one terminates the process, so a command that ignores its token cannot
 leave the application unkillable from the keyboard.
-- `AddServicesBundle<TBundle>` — register a `ServicesBundle` from `Ploch.Common.DependencyInjection`.
 
 `ConfigureCommandApp` terminates the chain and returns an `ICommandAppExecutor`,
 which exposes `Run` and `RunAsync`.

--- a/DocumentationSite/index.md
+++ b/DocumentationSite/index.md
@@ -108,6 +108,10 @@ usual hosting extension points are available:
 - `Dispose` — release the `Console.CancelKeyPress` handler and the `CancellationTokenSource` that
   `Create` installed. A builder constructed directly with your own source owns neither and leaves
   both alone.
+
+The token behind that source is handed to Spectre and reaches every command. The first Ctrl+C cancels
+it cooperatively; a second one terminates the process, so a command that ignores its token cannot
+leave the application unkillable from the keyboard.
 - `AddServicesBundle<TBundle>` — register a `ServicesBundle` from `Ploch.Common.DependencyInjection`.
 
 `ConfigureCommandApp` terminates the chain and returns an `ICommandAppExecutor`,

--- a/change-log/14-wire-cancellation-token.md
+++ b/change-log/14-wire-cancellation-token.md
@@ -1,0 +1,25 @@
+### Fixed
+
+- The cancellation token a command receives is now connected to the application.
+  `CommandAppExecutor` called Spectre's `Run(args)` and `RunAsync(args)`
+  overloads, which take no token, so the `CancellationTokenSource` that
+  `AppBuilder.Create` builds and cancels on Ctrl+C never reached any command:
+  it was registered in the container and otherwise unused. Commands were handed
+  a token that could never be cancelled, which made the whole feature inert.
+  The executor now passes that source's token to
+  `ICommandApp.Run(args, cancellationToken)` and
+  `ICommandApp.RunAsync(args, cancellationToken)` (#14).
+
+- Ctrl+C can interrupt the application again. The handler set `e.Cancel = true`
+  unconditionally, so a command that did not observe its token — a blocking
+  call, or a third-party library in a tight loop — left the process
+  unkillable from the keyboard. The handler now detaches itself, so the first
+  interrupt cancels cooperatively and a second one terminates the process (#32).
+
+### Changed
+
+- **Breaking:** `CommandAppExecutor` and `CommandAppConfigurator` take a
+  `CancellationTokenSource` as a second constructor argument. It is required
+  rather than optional so that an application built through either type cannot
+  silently end up without cancellation. Code constructing them directly must
+  supply one; `AppBuilder` does this already (#14).

--- a/change-log/14-wire-cancellation-token.md
+++ b/change-log/14-wire-cancellation-token.md
@@ -23,6 +23,18 @@
   terminates" needed a third press. The handler is now one-shot via
   `Interlocked.Exchange` (#32).
 
+- A cancelled run no longer pauses for input on the way out. With
+  `PauseBeforeExit` set, `Run`/`RunAsync` printed "Press Enter to exit..." and
+  blocked on stdin even after Ctrl+C, turning the shutdown the user had just
+  requested into a hang. The prompt is now skipped when the token is already
+  cancelled (#14).
+
+- The interrupt handler cancels before it writes to the console. It runs on the
+  `CancelKeyPress` thread, where console I/O can block or throw; writing first
+  risked skipping the cancellation entirely after `e.Cancel` had already
+  suppressed termination, leaving the application neither stopped nor killable
+  from the keyboard (#32).
+
 - An exception thrown by a consumer's cancellation callback no longer takes the
   process down. `CancellationTokenSource.Cancel` runs those callbacks
   synchronously and wraps anything they throw in an `AggregateException`, which
@@ -30,13 +42,22 @@
   caught and reported, so a failing callback cannot turn a graceful shutdown
   into a crash (#32).
 
+- An interrupt that arrives after the builder has been disposed no longer
+  suppresses itself. `AppBuilder` became `IDisposable` on `main` and releases the
+  cancellation source it owns, so `Cancel()` on the `CancelKeyPress` thread can
+  race disposal and throw `ObjectDisposedException`. The handler now hands that
+  interrupt back to the default path — `e.Cancel = false` — instead of
+  suppressing a press that cancels nothing: the run it exists to interrupt is
+  already over, and a suppressed press that does nothing is the unkillable
+  behaviour this change set exists to remove (#32).
+
 ### Changed
 
 - **Breaking:** `CommandAppExecutor` and `CommandAppConfigurator` take a
   `CancellationToken` as a second constructor argument. It is required rather
   than optional so that an application built through either type cannot
   silently end up without cancellation. Code constructing them directly must
-  supply one; `AppBuilder` passes `cancellationTokenSource.Token` already (#14).
+  supply one; `AppBuilder` passes the token of the source it owns already (#14).
 
   A token is taken rather than the `CancellationTokenSource` behind it, for
   three reasons. Neither type ever calls `Cancel`, so the source advertises a

--- a/change-log/14-wire-cancellation-token.md
+++ b/change-log/14-wire-cancellation-token.md
@@ -16,10 +16,39 @@
   unkillable from the keyboard. The handler now detaches itself, so the first
   interrupt cancels cooperatively and a second one terminates the process (#32).
 
+- A second Ctrl+C dispatched while the first was still being handled could be
+  suppressed as well, because unsubscribing inside the handler does not remove
+  the delegate from an invocation list a concurrent raise has already captured.
+  Both invocations set `e.Cancel = true`, so the advertised "second interrupt
+  terminates" needed a third press. The handler is now one-shot via
+  `Interlocked.Exchange` (#32).
+
+- An exception thrown by a consumer's cancellation callback no longer takes the
+  process down. `CancellationTokenSource.Cancel` runs those callbacks
+  synchronously and wraps anything they throw in an `AggregateException`, which
+  surfaced on the `CancelKeyPress` thread where it was unhandled. It is now
+  caught and reported, so a failing callback cannot turn a graceful shutdown
+  into a crash (#32).
+
 ### Changed
 
 - **Breaking:** `CommandAppExecutor` and `CommandAppConfigurator` take a
-  `CancellationTokenSource` as a second constructor argument. It is required
-  rather than optional so that an application built through either type cannot
+  `CancellationToken` as a second constructor argument. It is required rather
+  than optional so that an application built through either type cannot
   silently end up without cancellation. Code constructing them directly must
-  supply one; `AppBuilder` does this already (#14).
+  supply one; `AppBuilder` passes `cancellationTokenSource.Token` already (#14).
+
+  A token is taken rather than the `CancellationTokenSource` behind it, for
+  three reasons. Neither type ever calls `Cancel`, so the source advertises a
+  capability that is never used. The conversion only goes one way — `.Token` is
+  free, whereas turning a token back into a source needs
+  `CreateLinkedTokenSource` and another disposable to own — so accepting a token
+  accepts strictly more callers, including anyone holding one from
+  `IHostApplicationLifetime` or an outer pipeline. And because the source's
+  `.Token` was read at execution time rather than at construction, disposing it
+  in between made `Run`/`RunAsync` throw `ObjectDisposedException`; a token
+  captured up front stays usable after its source is disposed (#14).
+
+  `AppBuilder` still creates, cancels and registers the `CancellationTokenSource`
+  itself: a command resolving it from the container can legitimately request
+  shutdown, so that registration is deliberately unchanged.

--- a/change-log/14-wire-cancellation-token.md
+++ b/change-log/14-wire-cancellation-token.md
@@ -39,8 +39,10 @@
   process down. `CancellationTokenSource.Cancel` runs those callbacks
   synchronously and wraps anything they throw in an `AggregateException`, which
   surfaced on the `CancelKeyPress` thread where it was unhandled. It is now
-  caught and reported, so a failing callback cannot turn a graceful shutdown
-  into a crash (#32).
+  caught and reported, so the callback's own exception no longer escapes the
+  handler (#32). Reporting it writes to the console, which on that thread is
+  itself best-effort — the guarantee is that the callback cannot take the
+  process down, not that no console failure ever could.
 
 - An interrupt that arrives after the builder has been disposed no longer
   suppresses itself. `AppBuilder` became `IDisposable` on `main` and releases the

--- a/change-log/14-wire-cancellation-token.md
+++ b/change-log/14-wire-cancellation-token.md
@@ -47,11 +47,13 @@
 - An interrupt that arrives after the builder has been disposed no longer
   suppresses itself. `AppBuilder` became `IDisposable` on `main` and releases the
   cancellation source it owns, so `Cancel()` on the `CancelKeyPress` thread can
-  race disposal and throw `ObjectDisposedException`. The handler now hands that
-  interrupt back to the default path — `e.Cancel = false` — instead of
-  suppressing a press that cancels nothing: the run it exists to interrupt is
-  already over, and a suppressed press that does nothing is the unkillable
-  behaviour this change set exists to remove (#32).
+  race disposal. The handler now returns without touching the event arguments
+  instead of suppressing a press that cancels nothing: the run it exists to
+  interrupt is already over, and a suppressed press that does nothing is the
+  unkillable behaviour this change set exists to remove. It leaves the
+  arguments alone rather than writing `false` because they are shared by every
+  subscriber on the raise — the interrupt is left unsuppressed only where no
+  other handler has suppressed it (#32).
 
 ### Changed
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -86,11 +86,15 @@ Three things happen here that you do not have to write yourself:
   description, before any command runs.
 - **Hosting.** `Host.CreateDefaultBuilder` supplies configuration, logging and the service
   provider. Anything you register with `ConfigureServices` is injectable into commands.
-- **Ctrl+C.** `AppBuilder.Create` installs a `Console.CancelKeyPress` handler that cancels a
-  `CancellationTokenSource` instead of killing the process, which is what the token your commands
-  receive is linked to (see [Cancellation](#12-cancellation)). The builder owns both: disposing it
-  unsubscribes the handler and releases the source. `Console.CancelKeyPress` is process-wide, so a
-  builder that is never disposed keeps its handler installed for the life of the process.
+- **Ctrl+C.** `AppBuilder.Create` installs a `Console.CancelKeyPress` handler over a
+  `CancellationTokenSource`, and that source's token is the one your commands receive (see
+  [Cancellation](#12-cancellation)). The **first** interrupt cancels it cooperatively instead of
+  killing the process, so a command that honours its token can stop and tidy up; a **second**
+  interrupt takes the default path and terminates, so a command that ignores its token never leaves
+  the application unkillable from the keyboard. The builder owns both the source and the handler:
+  disposing it unsubscribes the handler and releases the source, and the handler also detaches itself
+  once an interrupt has been handled. `Console.CancelKeyPress` is process-wide, so a builder that is
+  neither disposed nor interrupted keeps its handler installed for the life of the process.
 
 `ConfigureServices` has two overloads — one taking just `IServiceCollection`, one taking the
 `HostBuilderContext` as well, which is how you reach `IConfiguration` during registration:
@@ -666,6 +670,26 @@ protected override async Task<ExitCode> DoExecuteAsync(CommandContext context,
 
 The base class treats cancellation as an outcome rather than a fault: an `OperationCanceledException`
 is not passed to `IExceptionHandler`, it becomes `ExitCode.Cancelled` (130).
+
+### Where the token comes from
+
+`AppBuilder.Create` owns the `CancellationTokenSource`, and `ConfigureCommandApp` hands its token to
+Spectre, which passes it to every command. The source is also registered in the container, so a
+command that needs to request shutdown itself can resolve a `CancellationTokenSource` and cancel it.
+
+Interrupting the application from the keyboard follows a two-step contract:
+
+| Interrupt | Effect |
+|---|---|
+| First Ctrl+C | Cancels the token; the command is expected to stop cooperatively. The application prints `Shutting down... press Ctrl+C again to force an exit.` |
+| Second Ctrl+C | Takes the default path and terminates the process, so a command that ignores its token cannot hang the application |
+
+A cancellation callback that throws is reported rather than allowed to escape — an unhandled
+exception on the `Console.CancelKeyPress` thread would terminate the process, which is the opposite
+of the shutdown being requested.
+
+`EnvironmentSettings.PauseBeforeExit` is skipped after cancellation: prompting for Enter on the way
+out of a shutdown the user just asked for would turn it into a hang.
 
 ## 13. Logging with Serilog
 

--- a/src/Spectre/CommandLine.Spectre/AppBuilder.cs
+++ b/src/Spectre/CommandLine.Spectre/AppBuilder.cs
@@ -76,6 +76,8 @@ public class AppBuilder : IDisposable
         var cancellationTokenSource = new CancellationTokenSource();
         try
         {
+            var interruptHandled = 0;
+
             // The delegate is held rather than re-converted so Dispose can unsubscribe this exact instance.
             // Console.CancelKeyPress is a process-wide event: left subscribed, it pins the source and the
             // closure for the life of the process, and every further Create call adds another handler on top.
@@ -89,7 +91,7 @@ public class AppBuilder : IDisposable
             // takes the default path and terminates the process. Suppressing every interrupt would leave the
             // application unkillable from the keyboard whenever the running command does not observe its token --
             // a blocking call, or a third-party library in a tight loop. Detaching here and in Dispose is not a
-            // conflict: removing a handler that is already gone is a no-op, so whichever happens first wins and
+            // conflict: removing a handler that is already gone is a no-op, so whichever happens first wins, and
             // an application that simply runs to completion still releases the subscription.
             //
             // Unsubscribing by method group rather than through cancelKeyPressHandler is deliberate: the variable
@@ -97,20 +99,39 @@ public class AppBuilder : IDisposable
             // it would not compile. Both conversions close over the same locals, so -= matches and removes it.
             void OnCancelKeyPress(object? sender, ConsoleCancelEventArgs e)
             {
+                // Unsubscribing inside the handler stops future raises, but it cannot remove this delegate from an
+                // invocation list a concurrent raise has already captured. Without this one-shot guard two interrupts
+                // dispatched close together could both set Cancel = true, suppressing the termination promised above
+                // and requiring a third press.
+                if (Interlocked.Exchange(ref interruptHandled, 1) != 0)
+                {
+                    e.Cancel = false;
+
+                    return;
+                }
+
                 Console.CancelKeyPress -= OnCancelKeyPress;
                 e.Cancel = true;
                 AnsiConsole.WriteLine("Shutting down... press Ctrl+C again to force an exit.");
 
-                // Ctrl+C is raised on the console's own thread and can land while Dispose runs on the main
-                // one. The source is then already gone, so there is nothing left to cancel - but the press
-                // was user-initiated and still gets an answer.
                 try
                 {
                     cancellationTokenSource.Cancel();
                 }
                 catch (ObjectDisposedException)
                 {
+                    // Ctrl+C is raised on the console's own thread and can land while Dispose runs on the main one.
+                    // The source is then already gone, so there is nothing left to cancel - but the press was
+                    // user-initiated and still gets an answer.
                     AnsiConsole.WriteLine("Shutdown already in progress.");
+                }
+                catch (AggregateException exception)
+                {
+                    // Cancel() invokes consumer cancellation callbacks synchronously and wraps anything they throw.
+                    // This runs on the CancelKeyPress thread, where an unhandled exception terminates the process --
+                    // the exact opposite of the graceful shutdown being requested. Reported rather than swallowed,
+                    // but only the message: a stack trace is noise while the application is already on its way out.
+                    AnsiConsole.WriteLine($"A cancellation callback failed during shutdown: {exception.Message}");
                 }
             }
         }
@@ -183,7 +204,7 @@ public class AppBuilder : IDisposable
 
         app.Configure(configurator);
 
-        return new CommandAppExecutor(app, _cancellationTokenSource);
+        return new CommandAppExecutor(app, _cancellationTokenSource.Token);
     }
 
     /// <summary>

--- a/src/Spectre/CommandLine.Spectre/AppBuilder.cs
+++ b/src/Spectre/CommandLine.Spectre/AppBuilder.cs
@@ -142,10 +142,6 @@ public class AppBuilder : IDisposable
 
                 lock (interruptGate.Sync)
                 {
-                    // Dispose is the one CancellationTokenSource member that may not run concurrently with the
-                    // others, and this handler runs on the console's own thread while Dispose runs on the main one.
-                    // The check and the Cancel therefore happen under one gate, and Cancel stays inside it because
-                    // it runs consumer callbacks synchronously.
                     if (interruptGate.SourceReleased)
                     {
                         // The run this handler exists to interrupt is already over. Leave the press to the default
@@ -153,27 +149,56 @@ public class AppBuilder : IDisposable
                         return;
                     }
 
-                    try
-                    {
-                        cancellationTokenSource.Cancel();
-                    }
-                    catch (AggregateException exception)
-                    {
-                        // Cancel() invokes consumer cancellation callbacks synchronously and wraps anything they
-                        // throw. An unhandled exception on this thread terminates the process -- the exact opposite
-                        // of the graceful shutdown being requested. Reported rather than swallowed, but only the
-                        // message: a stack trace is noise while the application is already on its way out.
-                        // Cancellation was still requested, so the interrupt is still handled cooperatively.
-                        e.Cancel = true;
-                        AnsiConsole.WriteLine($"A cancellation callback failed during shutdown: {exception.Message}");
+                    interruptGate.CancelInProgress = true;
+                }
 
-                        return;
+                string? callbackFailure = null;
+
+                // Cancel runs OUTSIDE the gate deliberately. It invokes consumer cancellation callbacks
+                // synchronously, and a callback is free to dispose this builder on this very thread. Holding a
+                // re-entrant lock across the call would not stop that: the nested Dispose would simply re-acquire
+                // the lock it already owns and tear the source down inside the Cancel still unwinding - the exact
+                // overlap the gate exists to prevent. Instead the call is flagged as in progress, and a Dispose
+                // arriving during it defers the release to us.
+                try
+                {
+                    cancellationTokenSource.Cancel();
+                }
+                catch (AggregateException exception)
+                {
+                    // Cancel() wraps anything the callbacks throw. An unhandled exception on this thread terminates
+                    // the process -- the exact opposite of the graceful shutdown being requested. Reported rather
+                    // than swallowed, but only the message: a stack trace is noise while the application is already
+                    // on its way out. Cancellation was still requested, so the interrupt is still handled.
+                    callbackFailure = exception.Message;
+                }
+                finally
+                {
+                    lock (interruptGate.Sync)
+                    {
+                        interruptGate.CancelInProgress = false;
+
+                        // A Dispose that arrived while Cancel was on the stack left the source for this thread to
+                        // release, now that nothing is running against it.
+                        if (interruptGate.DisposeDeferred && !interruptGate.SourceReleased)
+                        {
+                            interruptGate.SourceReleased = true;
+                            cancellationTokenSource.Dispose();
+                        }
                     }
                 }
 
-                // Announced only after cancellation has actually been requested, and outside the gate: this runs on
-                // the CancelKeyPress thread, where console I/O can block, and nothing else should wait behind it.
+                // Announced only after cancellation has actually been requested, and off the gate: this runs on the
+                // CancelKeyPress thread, where console I/O can block, and nothing should wait behind it.
                 e.Cancel = true;
+
+                if (callbackFailure is not null)
+                {
+                    AnsiConsole.WriteLine($"A cancellation callback failed during shutdown: {callbackFailure}");
+
+                    return;
+                }
+
                 AnsiConsole.WriteLine("Shutting down... press Ctrl+C again to force an exit.");
             }
         }
@@ -466,8 +491,19 @@ public class AppBuilder : IDisposable
             {
                 lock (_interruptGate.Sync)
                 {
-                    _interruptGate.SourceReleased = true;
-                    _cancellationTokenSource.Dispose();
+                    if (_interruptGate.CancelInProgress)
+                    {
+                        // Cancel() is on the stack - possibly on this very thread, reached through a cancellation
+                        // callback that disposed the builder. Disposing now would tear the source down inside the
+                        // call still unwinding, so the cancelling thread releases it instead. Deferring rather than
+                        // waiting also keeps Dispose from blocking on a consumer callback that never returns.
+                        _interruptGate.DisposeDeferred = true;
+                    }
+                    else if (!_interruptGate.SourceReleased)
+                    {
+                        _interruptGate.SourceReleased = true;
+                        _cancellationTokenSource.Dispose();
+                    }
                 }
             }
         }
@@ -494,19 +530,27 @@ public class AppBuilder : IDisposable
     ///     <see cref="CancellationTokenSource.Dispose()" />, which "must only be used when all other operations have
     ///     completed". The interrupt handler runs on the console's own thread and can therefore call
     ///     <see cref="CancellationTokenSource.Cancel()" /> while <see cref="AppBuilder.Dispose()" /> runs on the main
-    ///     one. Both take this gate so the two never overlap.
+    ///     one.
     ///     <para>
-    ///         <see cref="System.Threading.Lock" /> is re-entrant, so a cancellation callback that disposes the
-    ///         builder on the callback thread does not deadlock. A callback that blocks waiting on another thread to
-    ///         dispose it still would, which is inherent to running consumer callbacks under a lifetime gate.
+    ///         Rather than hold a lock across <c>Cancel()</c>, the call is flagged as in progress and disposal is
+    ///         deferred to whoever is cancelling. Holding a lock would not work: consumer cancellation callbacks run
+    ///         synchronously and one may dispose the builder on the cancelling thread, where a re-entrant lock is
+    ///         simply re-acquired and the source torn down inside the call still unwinding. Deferring also stops
+    ///         <see cref="AppBuilder.Dispose()" /> blocking behind a consumer callback that never returns.
     ///     </para>
     /// </remarks>
     private sealed class InterruptGate
     {
-        /// <summary>Gets the gate both cancellation and disposal of the owned source are taken under.</summary>
+        /// <summary>Gets the gate the state below is read and written under.</summary>
         public Lock Sync { get; } = new();
 
-        /// <summary>Gets or sets a value indicating whether disposal has claimed the source. Guarded by <see cref="Sync" />.</summary>
+        /// <summary>Gets or sets a value indicating whether <c>Cancel()</c> is currently on the stack.</summary>
+        public bool CancelInProgress { get; set; }
+
+        /// <summary>Gets or sets a value indicating whether a disposal arrived during cancellation and still owes a release.</summary>
+        public bool DisposeDeferred { get; set; }
+
+        /// <summary>Gets or sets a value indicating whether the source has been disposed.</summary>
         public bool SourceReleased { get; set; }
     }
 }

--- a/src/Spectre/CommandLine.Spectre/AppBuilder.cs
+++ b/src/Spectre/CommandLine.Spectre/AppBuilder.cs
@@ -66,10 +66,23 @@ public class AppBuilder : IDisposable
     /// <param name="args">The command-line arguments to initialize the application.</param>
     /// <returns>A new instance of <see cref="AppBuilder" />.</returns>
     /// <remarks>
-    ///     The returned builder owns both the cancellation source it creates and the <c>Console.CancelKeyPress</c>
-    ///     handler it installs, and releases them on <see cref="Dispose()" />. Dispose it once the application has
-    ///     finished running — the cancellation token stays live for the whole run, so an earlier scope exit would
-    ///     tear down the application it is meant to be shutting down.
+    ///     <para>
+    ///         This also installs a <see cref="Console.CancelKeyPress" /> handler and creates the
+    ///         <see cref="CancellationTokenSource" /> the application cancels through. The first Ctrl+C cancels that
+    ///         source cooperatively, so a command honouring its <see cref="CancellationToken" /> can stop and tidy up;
+    ///         a second Ctrl+C takes the default path and terminates the process, so a command that ignores its token
+    ///         never leaves the application unkillable from the keyboard.
+    ///     </para>
+    ///     <para>
+    ///         The source is registered in the container, so a command can resolve it to request shutdown itself.
+    ///     </para>
+    ///     <para>
+    ///         The returned builder owns both the source it creates and the handler it installs, and releases them on
+    ///         <see cref="Dispose()" />. Dispose it once the application has finished running — the cancellation token
+    ///         stays live for the whole run, so an earlier scope exit would tear down the application it is meant to
+    ///         be shutting down. The handler also detaches itself once an interrupt has been handled, so an
+    ///         interrupted application releases the subscription without waiting for disposal.
+    ///     </para>
     /// </remarks>
     public static AppBuilder Create(params IEnumerable<string> args)
     {
@@ -112,8 +125,10 @@ public class AppBuilder : IDisposable
 
                 Console.CancelKeyPress -= OnCancelKeyPress;
                 e.Cancel = true;
-                AnsiConsole.WriteLine("Shutting down... press Ctrl+C again to force an exit.");
 
+                // Cancel before writing anything. This runs on the CancelKeyPress thread, where console I/O can block
+                // or throw; doing it first would risk skipping the cancellation entirely after e.Cancel has already
+                // suppressed termination, leaving the application neither stopped nor killable from the keyboard.
                 try
                 {
                     cancellationTokenSource.Cancel();
@@ -121,18 +136,23 @@ public class AppBuilder : IDisposable
                 catch (ObjectDisposedException)
                 {
                     // Ctrl+C is raised on the console's own thread and can land while Dispose runs on the main one.
-                    // The source is then already gone, so there is nothing left to cancel - but the press was
-                    // user-initiated and still gets an answer.
-                    AnsiConsole.WriteLine("Shutdown already in progress.");
+                    // The source is then already gone and the run this handler exists to interrupt is over, so the
+                    // interrupt is handed back to the default path rather than suppressed: a press that both cancels
+                    // nothing and blocks termination is a press that does nothing.
+                    e.Cancel = false;
+
+                    return;
                 }
                 catch (AggregateException exception)
                 {
                     // Cancel() invokes consumer cancellation callbacks synchronously and wraps anything they throw.
-                    // This runs on the CancelKeyPress thread, where an unhandled exception terminates the process --
-                    // the exact opposite of the graceful shutdown being requested. Reported rather than swallowed,
-                    // but only the message: a stack trace is noise while the application is already on its way out.
+                    // An unhandled exception on this thread terminates the process -- the exact opposite of the
+                    // graceful shutdown being requested. Reported rather than swallowed, but only the message: a
+                    // stack trace is noise while the application is already on its way out.
                     AnsiConsole.WriteLine($"A cancellation callback failed during shutdown: {exception.Message}");
                 }
+
+                AnsiConsole.WriteLine("Shutting down... press Ctrl+C again to force an exit.");
             }
         }
         catch

--- a/src/Spectre/CommandLine.Spectre/AppBuilder.cs
+++ b/src/Spectre/CommandLine.Spectre/AppBuilder.cs
@@ -87,6 +87,12 @@ public class AppBuilder : IDisposable
     public static AppBuilder Create(params IEnumerable<string> args)
     {
         var cancellationTokenSource = new CancellationTokenSource();
+
+        // Declared out here so the catch below can unsubscribe it. Nothing has taken ownership until the
+        // builder is constructed, so a throw after the subscription would otherwise leave a handler on a
+        // process-wide event holding a disposed source - one that answers a later Ctrl+C by suppressing
+        // nothing and cancelling nothing.
+        ConsoleCancelEventHandler? cancelKeyPressHandler = null;
         try
         {
             var interruptHandled = 0;
@@ -94,7 +100,7 @@ public class AppBuilder : IDisposable
             // The delegate is held rather than re-converted so Dispose can unsubscribe this exact instance.
             // Console.CancelKeyPress is a process-wide event: left subscribed, it pins the source and the
             // closure for the life of the process, and every further Create call adds another handler on top.
-            ConsoleCancelEventHandler cancelKeyPressHandler = OnCancelKeyPress;
+            cancelKeyPressHandler = OnCancelKeyPress;
 
             Console.CancelKeyPress += cancelKeyPressHandler;
 
@@ -107,9 +113,10 @@ public class AppBuilder : IDisposable
             // conflict: removing a handler that is already gone is a no-op, so whichever happens first wins, and
             // an application that simply runs to completion still releases the subscription.
             //
-            // Unsubscribing by method group rather than through cancelKeyPressHandler is deliberate: the variable
-            // is not definitely assigned at the point this local function is converted to a delegate, so capturing
-            // it would not compile. Both conversions close over the same locals, so -= matches and removes it.
+            // Unsubscribing by method group rather than through cancelKeyPressHandler is deliberate: it keeps the
+            // handler independent of when that variable is assigned. Both conversions name the same method and
+            // close over the same locals, and delegate equality is by target and method rather than by reference,
+            // so -= matches the instance that was added.
             void OnCancelKeyPress(object? sender, ConsoleCancelEventArgs e)
             {
                 // Unsubscribing inside the handler stops future raises, but it cannot remove this delegate from an
@@ -157,7 +164,13 @@ public class AppBuilder : IDisposable
         }
         catch
         {
-            // Nothing has taken ownership yet, so the source would otherwise leak on a failed construction.
+            // Nothing has taken ownership yet, so both the subscription and the source would otherwise leak
+            // on a failed construction. Removing a handler that was never added is a no-op.
+            if (cancelKeyPressHandler is not null)
+            {
+                Console.CancelKeyPress -= cancelKeyPressHandler;
+            }
+
             cancellationTokenSource.Dispose();
 
             throw;

--- a/src/Spectre/CommandLine.Spectre/AppBuilder.cs
+++ b/src/Spectre/CommandLine.Spectre/AppBuilder.cs
@@ -85,9 +85,21 @@ public class AppBuilder : IDisposable
 
             return new(new(args), cancellationTokenSource, cancelKeyPressHandler, ownsCancellationTokenSource: true);
 
+            // The handler also detaches itself, so the first interrupt is handled cooperatively and a second one
+            // takes the default path and terminates the process. Suppressing every interrupt would leave the
+            // application unkillable from the keyboard whenever the running command does not observe its token --
+            // a blocking call, or a third-party library in a tight loop. Detaching here and in Dispose is not a
+            // conflict: removing a handler that is already gone is a no-op, so whichever happens first wins and
+            // an application that simply runs to completion still releases the subscription.
+            //
+            // Unsubscribing by method group rather than through cancelKeyPressHandler is deliberate: the variable
+            // is not definitely assigned at the point this local function is converted to a delegate, so capturing
+            // it would not compile. Both conversions close over the same locals, so -= matches and removes it.
             void OnCancelKeyPress(object? sender, ConsoleCancelEventArgs e)
             {
-                AnsiConsole.WriteLine("Shutting down...");
+                Console.CancelKeyPress -= OnCancelKeyPress;
+                e.Cancel = true;
+                AnsiConsole.WriteLine("Shutting down... press Ctrl+C again to force an exit.");
 
                 // Ctrl+C is raised on the console's own thread and can land while Dispose runs on the main
                 // one. The source is then already gone, so there is nothing left to cancel - but the press
@@ -100,8 +112,6 @@ public class AppBuilder : IDisposable
                 {
                     AnsiConsole.WriteLine("Shutdown already in progress.");
                 }
-
-                e.Cancel = true;
             }
         }
         catch
@@ -173,7 +183,7 @@ public class AppBuilder : IDisposable
 
         app.Configure(configurator);
 
-        return new CommandAppExecutor(app);
+        return new CommandAppExecutor(app, _cancellationTokenSource);
     }
 
     /// <summary>

--- a/src/Spectre/CommandLine.Spectre/AppBuilder.cs
+++ b/src/Spectre/CommandLine.Spectre/AppBuilder.cs
@@ -30,8 +30,12 @@ public class AppBuilder : IDisposable
     private readonly CancellationTokenSource _cancellationTokenSource;
     private readonly List<Action<IHostBuilder>> _hostBuilderConfigurators = [];
 
-    /// <summary>Whether <see cref="_cancellationTokenSource" /> was created here and is therefore ours to dispose.</summary>
-    private readonly bool _ownsCancellationTokenSource;
+    /// <summary>
+    ///     Non-<see langword="null" /> exactly when this builder created the cancellation source and is therefore
+    ///     the one to dispose it. Also the gate that keeps that disposal from overlapping the interrupt handler's
+    ///     cancellation.
+    /// </summary>
+    private readonly InterruptGate? _interruptGate;
 
     private readonly List<Action<HostBuilderContext, IServiceCollection>> _serviceCollectionConfigurators = [];
     private readonly HashSet<IServicesBundle> _servicesBundles = new() { new AppServicesBundle() };
@@ -46,18 +50,18 @@ public class AppBuilder : IDisposable
     ///     <see cref="Dispose()" /> leaves it alone. Use <see cref="Create" /> to have the builder own one instead.
     /// </param>
     public AppBuilder(ConsoleAppInfo appInfo, CancellationTokenSource cancellationTokenSource)
-        : this(appInfo, cancellationTokenSource, cancelKeyPressHandler: null, ownsCancellationTokenSource: false)
+        : this(appInfo, cancellationTokenSource, cancelKeyPressHandler: null, interruptGate: null)
     { }
 
     private AppBuilder(ConsoleAppInfo appInfo,
                        CancellationTokenSource cancellationTokenSource,
                        ConsoleCancelEventHandler? cancelKeyPressHandler,
-                       bool ownsCancellationTokenSource)
+                       InterruptGate? interruptGate)
     {
         _appInfo = appInfo;
         _cancellationTokenSource = cancellationTokenSource;
         _cancelKeyPressHandler = cancelKeyPressHandler;
-        _ownsCancellationTokenSource = ownsCancellationTokenSource;
+        _interruptGate = interruptGate;
     }
 
     /// <summary>
@@ -96,6 +100,7 @@ public class AppBuilder : IDisposable
         try
         {
             var interruptHandled = 0;
+            var interruptGate = new InterruptGate();
 
             // The delegate is held rather than re-converted so Dispose can unsubscribe this exact instance.
             // Console.CancelKeyPress is a process-wide event: left subscribed, it pins the source and the
@@ -104,7 +109,7 @@ public class AppBuilder : IDisposable
 
             Console.CancelKeyPress += cancelKeyPressHandler;
 
-            return new(new(args), cancellationTokenSource, cancelKeyPressHandler, ownsCancellationTokenSource: true);
+            return new(new(args), cancellationTokenSource, cancelKeyPressHandler, interruptGate);
 
             // The handler also detaches itself, so the first interrupt is handled cooperatively and a second one
             // takes the default path and terminates the process. Suppressing every interrupt would leave the
@@ -121,44 +126,54 @@ public class AppBuilder : IDisposable
             {
                 // Unsubscribing inside the handler stops future raises, but it cannot remove this delegate from an
                 // invocation list a concurrent raise has already captured. Without this one-shot guard two interrupts
-                // dispatched close together could both set Cancel = true, suppressing the termination promised above
-                // and requiring a third press.
+                // dispatched close together could both suppress termination, and the second press promised above
+                // would need a third.
+                //
+                // Returning without touching e.Cancel is deliberate. The event arguments are one instance shared by
+                // every subscriber on this raise and the runtime reads whatever is left after the last handler
+                // returns, so writing false here would override a suppression some other subscriber legitimately
+                // asked for. False is already the default; this handler only ever adds a true of its own.
                 if (Interlocked.Exchange(ref interruptHandled, 1) != 0)
                 {
-                    e.Cancel = false;
-
                     return;
                 }
 
                 Console.CancelKeyPress -= OnCancelKeyPress;
+
+                lock (interruptGate.Sync)
+                {
+                    // Dispose is the one CancellationTokenSource member that may not run concurrently with the
+                    // others, and this handler runs on the console's own thread while Dispose runs on the main one.
+                    // The check and the Cancel therefore happen under one gate, and Cancel stays inside it because
+                    // it runs consumer callbacks synchronously.
+                    if (interruptGate.SourceReleased)
+                    {
+                        // The run this handler exists to interrupt is already over. Leave the press to the default
+                        // path: one that cancels nothing and blocks termination too would do nothing at all.
+                        return;
+                    }
+
+                    try
+                    {
+                        cancellationTokenSource.Cancel();
+                    }
+                    catch (AggregateException exception)
+                    {
+                        // Cancel() invokes consumer cancellation callbacks synchronously and wraps anything they
+                        // throw. An unhandled exception on this thread terminates the process -- the exact opposite
+                        // of the graceful shutdown being requested. Reported rather than swallowed, but only the
+                        // message: a stack trace is noise while the application is already on its way out.
+                        // Cancellation was still requested, so the interrupt is still handled cooperatively.
+                        e.Cancel = true;
+                        AnsiConsole.WriteLine($"A cancellation callback failed during shutdown: {exception.Message}");
+
+                        return;
+                    }
+                }
+
+                // Announced only after cancellation has actually been requested, and outside the gate: this runs on
+                // the CancelKeyPress thread, where console I/O can block, and nothing else should wait behind it.
                 e.Cancel = true;
-
-                // Cancel before writing anything. This runs on the CancelKeyPress thread, where console I/O can block
-                // or throw; doing it first would risk skipping the cancellation entirely after e.Cancel has already
-                // suppressed termination, leaving the application neither stopped nor killable from the keyboard.
-                try
-                {
-                    cancellationTokenSource.Cancel();
-                }
-                catch (ObjectDisposedException)
-                {
-                    // Ctrl+C is raised on the console's own thread and can land while Dispose runs on the main one.
-                    // The source is then already gone and the run this handler exists to interrupt is over, so the
-                    // interrupt is handed back to the default path rather than suppressed: a press that both cancels
-                    // nothing and blocks termination is a press that does nothing.
-                    e.Cancel = false;
-
-                    return;
-                }
-                catch (AggregateException exception)
-                {
-                    // Cancel() invokes consumer cancellation callbacks synchronously and wraps anything they throw.
-                    // An unhandled exception on this thread terminates the process -- the exact opposite of the
-                    // graceful shutdown being requested. Reported rather than swallowed, but only the message: a
-                    // stack trace is noise while the application is already on its way out.
-                    AnsiConsole.WriteLine($"A cancellation callback failed during shutdown: {exception.Message}");
-                }
-
                 AnsiConsole.WriteLine("Shutting down... press Ctrl+C again to force an exit.");
             }
         }
@@ -442,11 +457,18 @@ public class AppBuilder : IDisposable
                 Console.CancelKeyPress -= _cancelKeyPressHandler;
             }
 
-            // Only a source this builder created. One handed in through the public constructor belongs to the
-            // caller and may still be in use after the builder is gone.
-            if (_ownsCancellationTokenSource)
+            // Only a source this builder created - the gate exists exactly then. One handed in through the public
+            // constructor belongs to the caller and may still be in use after the builder is gone.
+            //
+            // Released under the same gate the interrupt handler cancels through, because Dispose may not overlap
+            // Cancel. Unsubscribing above stops new raises but cannot recall one already in flight.
+            if (_interruptGate is not null)
             {
-                _cancellationTokenSource.Dispose();
+                lock (_interruptGate.Sync)
+                {
+                    _interruptGate.SourceReleased = true;
+                    _cancellationTokenSource.Dispose();
+                }
             }
         }
 
@@ -462,5 +484,29 @@ public class AppBuilder : IDisposable
                 services.AddServicesBundle(servicesBundle, context.Configuration);
             }
         }
+    }
+
+    /// <summary>
+    ///     Serialises the interrupt handler's cancellation against disposal of the source it cancels.
+    /// </summary>
+    /// <remarks>
+    ///     <see cref="CancellationTokenSource" /> documents every public member as thread-safe <em>except</em>
+    ///     <see cref="CancellationTokenSource.Dispose()" />, which "must only be used when all other operations have
+    ///     completed". The interrupt handler runs on the console's own thread and can therefore call
+    ///     <see cref="CancellationTokenSource.Cancel()" /> while <see cref="AppBuilder.Dispose()" /> runs on the main
+    ///     one. Both take this gate so the two never overlap.
+    ///     <para>
+    ///         <see cref="System.Threading.Lock" /> is re-entrant, so a cancellation callback that disposes the
+    ///         builder on the callback thread does not deadlock. A callback that blocks waiting on another thread to
+    ///         dispose it still would, which is inherent to running consumer callbacks under a lifetime gate.
+    ///     </para>
+    /// </remarks>
+    private sealed class InterruptGate
+    {
+        /// <summary>Gets the gate both cancellation and disposal of the owned source are taken under.</summary>
+        public Lock Sync { get; } = new();
+
+        /// <summary>Gets or sets a value indicating whether disposal has claimed the source. Guarded by <see cref="Sync" />.</summary>
+        public bool SourceReleased { get; set; }
     }
 }

--- a/src/Spectre/CommandLine.Spectre/CommandAppConfigurator.cs
+++ b/src/Spectre/CommandLine.Spectre/CommandAppConfigurator.cs
@@ -7,12 +7,11 @@ namespace Ploch.CommandLine.Spectre;
 ///     Implements the <see cref="ICommandAppConfigurator" /> interface to configure command-line applications.
 /// </summary>
 /// <param name="commandApp">The command application to configure.</param>
-/// <param name="cancellationTokenSource">
-///     The source whose token the resulting executor hands to Spectre, and through it to every command. Required
-///     rather than optional so that an application configured through this type cannot silently end up without
-///     cancellation.
+/// <param name="cancellationToken">
+///     The token the resulting executor hands to Spectre, and through it to every command. Required rather than
+///     optional so that an application configured through this type cannot silently end up without cancellation.
 /// </param>
-public class CommandAppConfigurator(ICommandApp commandApp, CancellationTokenSource cancellationTokenSource) : ICommandAppConfigurator
+public class CommandAppConfigurator(ICommandApp commandApp, CancellationToken cancellationToken) : ICommandAppConfigurator
 {
     /// <summary>
     ///     Configures the command-line application using the provided configuration action.
@@ -24,6 +23,6 @@ public class CommandAppConfigurator(ICommandApp commandApp, CancellationTokenSou
     {
         commandApp.Configure(configuration.NotNull());
 
-        return new CommandAppExecutor(commandApp, cancellationTokenSource);
+        return new CommandAppExecutor(commandApp, cancellationToken);
     }
 }

--- a/src/Spectre/CommandLine.Spectre/CommandAppConfigurator.cs
+++ b/src/Spectre/CommandLine.Spectre/CommandAppConfigurator.cs
@@ -7,7 +7,12 @@ namespace Ploch.CommandLine.Spectre;
 ///     Implements the <see cref="ICommandAppConfigurator" /> interface to configure command-line applications.
 /// </summary>
 /// <param name="commandApp">The command application to configure.</param>
-public class CommandAppConfigurator(ICommandApp commandApp) : ICommandAppConfigurator
+/// <param name="cancellationTokenSource">
+///     The source whose token the resulting executor hands to Spectre, and through it to every command. Required
+///     rather than optional so that an application configured through this type cannot silently end up without
+///     cancellation.
+/// </param>
+public class CommandAppConfigurator(ICommandApp commandApp, CancellationTokenSource cancellationTokenSource) : ICommandAppConfigurator
 {
     /// <summary>
     ///     Configures the command-line application using the provided configuration action.
@@ -19,6 +24,6 @@ public class CommandAppConfigurator(ICommandApp commandApp) : ICommandAppConfigu
     {
         commandApp.Configure(configuration.NotNull());
 
-        return new CommandAppExecutor(commandApp);
+        return new CommandAppExecutor(commandApp, cancellationTokenSource);
     }
 }

--- a/src/Spectre/CommandLine.Spectre/CommandAppExecutor.cs
+++ b/src/Spectre/CommandLine.Spectre/CommandAppExecutor.cs
@@ -7,12 +7,19 @@ namespace Ploch.CommandLine.Spectre;
 ///     Implements the <see cref="ICommandAppExecutor" /> interface to execute command-line applications.
 /// </summary>
 /// <param name="commandApp">The command application to execute.</param>
-/// <param name="cancellationTokenSource">
-///     The source whose token is handed to Spectre, and through it to every command. This is the source
-///     <see cref="AppBuilder.Create" /> cancels when the user interrupts the application, so a command that honours its
+/// <param name="cancellationToken">
+///     The token handed to Spectre, and through it to every command. <see cref="AppBuilder.Create" /> cancels the
+///     source behind this token when the user interrupts the application, so a command that honours its
 ///     <see cref="CancellationToken" /> stops when they do.
 /// </param>
-public class CommandAppExecutor(ICommandApp commandApp, CancellationTokenSource cancellationTokenSource) : ICommandAppExecutor
+/// <remarks>
+///     The token is taken rather than the <see cref="CancellationTokenSource" /> behind it. This type only ever
+///     observes cancellation, it never requests it, so it has no use for the source. Taking the token also decouples
+///     execution from the source's lifetime: <see cref="CancellationTokenSource.Token" /> throws
+///     <see cref="ObjectDisposedException" /> once the source is disposed, whereas a token captured beforehand stays
+///     usable.
+/// </remarks>
+public class CommandAppExecutor(ICommandApp commandApp, CancellationToken cancellationToken) : ICommandAppExecutor
 {
     /// <summary>
     ///     Executes the command-line application synchronously with the specified arguments.
@@ -21,7 +28,7 @@ public class CommandAppExecutor(ICommandApp commandApp, CancellationTokenSource 
     /// <returns>An integer representing the exit code of the application, where 0 typically indicates success.</returns>
     public int Run(params IEnumerable<string> args)
     {
-        var result = commandApp.Run(args, cancellationTokenSource.Token);
+        var result = commandApp.Run(args, cancellationToken);
 
         PauseBeforeExitIfRequested();
 
@@ -38,7 +45,7 @@ public class CommandAppExecutor(ICommandApp commandApp, CancellationTokenSource 
     /// </returns>
     public async Task<int> RunAsync(params IEnumerable<string> args)
     {
-        var result = await commandApp.RunAsync(args, cancellationTokenSource.Token).ConfigureAwait(false);
+        var result = await commandApp.RunAsync(args, cancellationToken).ConfigureAwait(false);
 
         PauseBeforeExitIfRequested();
 

--- a/src/Spectre/CommandLine.Spectre/CommandAppExecutor.cs
+++ b/src/Spectre/CommandLine.Spectre/CommandAppExecutor.cs
@@ -53,12 +53,19 @@ public class CommandAppExecutor(ICommandApp commandApp, CancellationToken cancel
     }
 
     /// <summary>
-    ///     Waits for the user to press Enter when <see cref="EnvironmentSettings.PauseBeforeExit" /> is set.
-    ///     Applied identically by <see cref="Run" /> and <see cref="RunAsync" />.
+    ///     Waits for the user to press Enter when <see cref="EnvironmentSettings.PauseBeforeExit" /> is set and the
+    ///     run was not cancelled. Applied identically by <see cref="Run" /> and <see cref="RunAsync" />.
     /// </summary>
-    private static void PauseBeforeExitIfRequested()
+    private void PauseBeforeExitIfRequested()
     {
         if (!EnvironmentSettings.Current.PauseBeforeExit)
+        {
+            return;
+        }
+
+        // Skipped after cancellation: the user has already asked the application to stop, so prompting them to press
+        // Enter before it will exit turns a requested shutdown into a hang.
+        if (cancellationToken.IsCancellationRequested)
         {
             return;
         }

--- a/src/Spectre/CommandLine.Spectre/CommandAppExecutor.cs
+++ b/src/Spectre/CommandLine.Spectre/CommandAppExecutor.cs
@@ -7,7 +7,12 @@ namespace Ploch.CommandLine.Spectre;
 ///     Implements the <see cref="ICommandAppExecutor" /> interface to execute command-line applications.
 /// </summary>
 /// <param name="commandApp">The command application to execute.</param>
-public class CommandAppExecutor(ICommandApp commandApp) : ICommandAppExecutor
+/// <param name="cancellationTokenSource">
+///     The source whose token is handed to Spectre, and through it to every command. This is the source
+///     <see cref="AppBuilder.Create" /> cancels when the user interrupts the application, so a command that honours its
+///     <see cref="CancellationToken" /> stops when they do.
+/// </param>
+public class CommandAppExecutor(ICommandApp commandApp, CancellationTokenSource cancellationTokenSource) : ICommandAppExecutor
 {
     /// <summary>
     ///     Executes the command-line application synchronously with the specified arguments.
@@ -16,7 +21,7 @@ public class CommandAppExecutor(ICommandApp commandApp) : ICommandAppExecutor
     /// <returns>An integer representing the exit code of the application, where 0 typically indicates success.</returns>
     public int Run(params IEnumerable<string> args)
     {
-        var result = commandApp.Run(args);
+        var result = commandApp.Run(args, cancellationTokenSource.Token);
 
         PauseBeforeExitIfRequested();
 
@@ -33,7 +38,7 @@ public class CommandAppExecutor(ICommandApp commandApp) : ICommandAppExecutor
     /// </returns>
     public async Task<int> RunAsync(params IEnumerable<string> args)
     {
-        var result = await commandApp.RunAsync(args).ConfigureAwait(false);
+        var result = await commandApp.RunAsync(args, cancellationTokenSource.Token).ConfigureAwait(false);
 
         PauseBeforeExitIfRequested();
 

--- a/tests/Spectre/CommandLine.Spectre.Tests/AppBuilderTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/AppBuilderTests.cs
@@ -195,6 +195,32 @@ public sealed class AppBuilderTests : IDisposable
         recorder.CancellationTokenSource.Should().BeSameAs(cancellationTokenSource, "commands cancel the application through this source");
     }
 
+    /// <summary>
+    ///     The DI-registration test above passes even if <see cref="AppBuilder.ConfigureCommandApp" /> hands the
+    ///     executor an unrelated token, because it only inspects the container. This one drives the real Spectre
+    ///     pipeline and asserts on the token the command was actually invoked with, so a regression to
+    ///     <c>CancellationToken.None</c> at the executor call site fails here.
+    /// </summary>
+    [Fact]
+    public void ConfigureCommandApp_should_hand_the_running_command_the_token_of_the_source_it_was_built_with()
+    {
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        var recorder = RunProbeCommand(_ => { }, cancellationTokenSource);
+
+        recorder.ExitCode.Should().Be(0);
+        recorder.ExecutionToken
+                .CanBeCanceled.Should()
+                .BeTrue("CancellationToken.None can never be cancelled, which would make the whole feature inert");
+        recorder.ExecutionToken.IsCancellationRequested.Should().BeFalse();
+
+        cancellationTokenSource.Cancel();
+
+        recorder.ExecutionToken
+                .IsCancellationRequested.Should()
+                .BeTrue("the command must observe the very source the application was built with, not a detached one");
+    }
+
     [Fact]
     public void Create_should_feed_the_supplied_arguments_into_the_host_configuration()
     {
@@ -443,6 +469,12 @@ public sealed class AppBuilderTests : IDisposable
         public string? SecondConfigurationValue { get; set; }
 
         public CancellationTokenSource? CancellationTokenSource { get; set; }
+
+        /// <summary>
+        ///     The token Spectre handed to <c>Execute</c>. Distinct from <see cref="CancellationTokenSource" />,
+        ///     which only proves the source reached the container: this proves it reached the running command.
+        /// </summary>
+        public CancellationToken ExecutionToken { get; set; }
     }
 
     private sealed class ProbeSettings : CommandSettings
@@ -461,6 +493,7 @@ public sealed class AppBuilderTests : IDisposable
             recorder.ConfigurationValue = configuration["probe:key"];
             recorder.SecondConfigurationValue = configuration["probe:other"];
             recorder.CancellationTokenSource = cancellationTokenSource;
+            recorder.ExecutionToken = cancellationToken;
             recorder.MarkerNames.AddRange(services.GetServices<Marker>().Select(marker => marker.Name));
             recorder.Marker = services.GetService<Marker>();
 

--- a/tests/Spectre/CommandLine.Spectre.Tests/AppBuilderTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/AppBuilderTests.cs
@@ -479,6 +479,37 @@ public sealed class AppBuilderTests : IDisposable
     }
 
     [Fact]
+    public void CancelKeyPress_should_defer_disposal_a_cancellation_callback_asks_for_until_cancellation_unwinds()
+    {
+        using var builder = AppBuilder.Create().WithName("Widget Tool");
+        var handler = GetInstalledCancelKeyPressHandler(builder);
+        var cancellationTokenSource = GetOwnedCancellationTokenSource(builder);
+        var callbackRan = false;
+
+        // The re-entrant case: Cancel() runs this synchronously, so Dispose is reached from inside the very
+        // call that is still unwinding. Holding a re-entrant lock across Cancel would not prevent the overlap -
+        // the nested Dispose would simply re-acquire the lock it already owns.
+        using var registration = cancellationTokenSource.Token.Register(() =>
+                                                                        {
+                                                                            callbackRan = true;
+                                                                            builder.Dispose();
+                                                                        });
+
+        var interrupt = NewConsoleCancelEventArgs();
+
+        var act = () => handler(sender: null, interrupt);
+
+        act.Should().NotThrow("disposing from a cancellation callback must not tear the source down mid-Cancel");
+        callbackRan.Should().BeTrue("the callback has to have run for this to be testing anything");
+        interrupt.Cancel.Should().BeTrue("cancellation was still requested, so the interrupt was handled");
+
+        var useAfterDispose = () => cancellationTokenSource.Token;
+        useAfterDispose.Should()
+                       .Throw<ObjectDisposedException>("the disposal was deferred, not skipped - the cancelling "
+                                                       + "thread releases the source once Cancel has unwound");
+    }
+
+    [Fact]
     public void CancelKeyPress_should_not_suppress_an_interrupt_that_arrives_after_disposal()
     {
         var builder = AppBuilder.Create().WithName("Widget Tool");

--- a/tests/Spectre/CommandLine.Spectre.Tests/AppBuilderTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/AppBuilderTests.cs
@@ -459,6 +459,26 @@ public sealed class AppBuilderTests : IDisposable
     }
 
     [Fact]
+    public void CancelKeyPress_should_report_a_failing_cancellation_callback_rather_than_let_it_escape()
+    {
+        using var builder = AppBuilder.Create().WithName("Widget Tool");
+        var handler = GetInstalledCancelKeyPressHandler(builder);
+
+        // Cancel() runs consumer callbacks synchronously and wraps anything they throw in an
+        // AggregateException. Unhandled on the CancelKeyPress thread that terminates the process, which is
+        // the opposite of the graceful shutdown the interrupt asked for.
+        using var registration = GetOwnedCancellationTokenSource(builder)
+                                 .Token.Register(() => throw new InvalidOperationException("callback exploded"));
+        var interrupt = NewConsoleCancelEventArgs();
+
+        var act = () => handler(sender: null, interrupt);
+
+        act.Should().NotThrow("an exception escaping here would kill the process during a requested shutdown");
+        interrupt.Cancel.Should().BeTrue("a consumer's failing callback must not turn a cooperative shutdown into a kill");
+        _console.Output.Should().Contain("callback exploded", "the failure is reported rather than silently swallowed");
+    }
+
+    [Fact]
     public void CancelKeyPress_should_not_suppress_an_interrupt_that_arrives_after_disposal()
     {
         var builder = AppBuilder.Create().WithName("Widget Tool");

--- a/tests/Spectre/CommandLine.Spectre.Tests/AppBuilderTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/AppBuilderTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Configuration;
+﻿using System.Reflection;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Ploch.CommandLine.Spectre.Tests.Testing;
@@ -424,6 +425,54 @@ public sealed class AppBuilderTests : IDisposable
            .Throw<ObjectDisposedException>("building after disposal would publish a released cancellation source to the application's services");
     }
 
+    [Fact]
+    public void CancelKeyPress_should_cancel_the_token_and_suppress_termination_on_the_first_interrupt()
+    {
+        using var builder = AppBuilder.Create().WithName("Widget Tool");
+        var handler = GetInstalledCancelKeyPressHandler(builder);
+        var interrupt = NewConsoleCancelEventArgs();
+
+        handler(sender: null, interrupt);
+
+        interrupt.Cancel.Should().BeTrue("the first interrupt is handled cooperatively rather than killing the process");
+        GetOwnedCancellationTokenSource(builder)
+            .IsCancellationRequested.Should()
+            .BeTrue("the interrupt has to reach the token the running command was given");
+    }
+
+    [Fact]
+    public void CancelKeyPress_should_not_suppress_a_second_interrupt()
+    {
+        using var builder = AppBuilder.Create().WithName("Widget Tool");
+        var handler = GetInstalledCancelKeyPressHandler(builder);
+
+        var first = NewConsoleCancelEventArgs();
+        handler(sender: null, first);
+
+        var second = NewConsoleCancelEventArgs();
+        handler(sender: null, second);
+
+        first.Cancel.Should().BeTrue();
+        second.Cancel.Should()
+              .BeFalse("the handler is one-shot: a second interrupt takes the default path so a command that ignores "
+                       + "its token cannot leave the application unkillable from the keyboard");
+    }
+
+    [Fact]
+    public void CancelKeyPress_should_not_suppress_an_interrupt_that_arrives_after_disposal()
+    {
+        var builder = AppBuilder.Create().WithName("Widget Tool");
+        var handler = GetInstalledCancelKeyPressHandler(builder);
+        builder.Dispose();
+
+        var interrupt = NewConsoleCancelEventArgs();
+        handler(sender: null, interrupt);
+
+        interrupt.Cancel.Should()
+                 .BeFalse("the source is gone, so there is nothing to cancel - suppressing the press as well would "
+                          + "leave one that neither stops nor terminates the application");
+    }
+
     /// <summary>
     ///     Builds an application configured by <paramref name="configure" /> and runs a probe command through it.
     ///     The probe reports back through a static slot rather than a registered service, so that the helper's own
@@ -448,6 +497,44 @@ public sealed class AppBuilderTests : IDisposable
 
         return recorder;
     }
+
+    /// <summary>
+    ///     Returns the <c>Console.CancelKeyPress</c> handler <see cref="AppBuilder.Create" /> installed.
+    /// </summary>
+    /// <remarks>
+    ///     Reached through the field rather than the event because <c>Console.CancelKeyPress</c> cannot be raised from
+    ///     a test and the handler itself is a local function inside <c>Create</c>. The alternative — spawning a child
+    ///     process and sending it a real interrupt — is operating-system specific and flaky under CI, and would test
+    ///     the harness as much as the handler. The behaviour asserted here is genuinely observable; only the route to
+    ///     it is not.
+    /// </remarks>
+    private static ConsoleCancelEventHandler GetInstalledCancelKeyPressHandler(AppBuilder builder)
+    {
+        var field = typeof(AppBuilder).GetField("_cancelKeyPressHandler", BindingFlags.Instance | BindingFlags.NonPublic);
+        field.Should().NotBeNull("the builder keeps the handler so that Dispose can unsubscribe that exact instance");
+
+        return (ConsoleCancelEventHandler)field!.GetValue(builder)!;
+    }
+
+    /// <summary>Returns the cancellation source <see cref="AppBuilder.Create" /> made and owns.</summary>
+    private static CancellationTokenSource GetOwnedCancellationTokenSource(AppBuilder builder)
+    {
+        var field = typeof(AppBuilder).GetField("_cancellationTokenSource", BindingFlags.Instance | BindingFlags.NonPublic);
+        field.Should().NotBeNull();
+
+        return (CancellationTokenSource)field!.GetValue(builder)!;
+    }
+
+    /// <summary>
+    ///     Creates a <see cref="ConsoleCancelEventArgs" />, which has no public constructor — only the runtime raises
+    ///     the event normally.
+    /// </summary>
+    private static ConsoleCancelEventArgs NewConsoleCancelEventArgs() =>
+        (ConsoleCancelEventArgs)Activator.CreateInstance(typeof(ConsoleCancelEventArgs),
+                                                         BindingFlags.Instance | BindingFlags.NonPublic,
+                                                         binder: null,
+                                                         [ConsoleSpecialKey.ControlC],
+                                                         culture: null)!;
 
     private sealed class Marker
     {

--- a/tests/Spectre/CommandLine.Spectre.Tests/CommandAppConfiguratorTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/CommandAppConfiguratorTests.cs
@@ -41,6 +41,32 @@ public sealed class CommandAppConfiguratorTests : IDisposable
     }
 
     [Fact]
+    public void Configure_should_hand_the_executor_the_token_it_was_built_with()
+    {
+        var commandApp = new Mock<ICommandApp>();
+        CancellationToken received = default;
+        commandApp.Setup(app => app.Run(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+                  .Callback<IEnumerable<string>, CancellationToken>((_, token) => received = token)
+                  .Returns(0);
+        EnvironmentSettings.Current = new EnvironmentSettings(isDebugging: false, pauseBeforeExit: false, new Dictionary<string, string?>());
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        new CommandAppConfigurator(commandApp.Object, cancellationTokenSource.Token).Configure(_ => { }).Run("build");
+
+        // Asserting on the token's own behaviour rather than on It.IsAny<CancellationToken>(): a default token
+        // satisfies that matcher just as well, so a configurator that dropped its token and built the executor
+        // with CancellationToken.None would pass every other test in this class.
+        received.CanBeCanceled.Should().BeTrue("an executor built with a default token makes cancellation inert");
+        received.IsCancellationRequested.Should().BeFalse();
+
+        cancellationTokenSource.Cancel();
+
+        received.IsCancellationRequested
+                .Should()
+                .BeTrue("the configurator must pass the token it was constructed with to the executor it builds");
+    }
+
+    [Fact]
     public void Configure_should_reject_a_null_configuration_action()
     {
         var configurator = new CommandAppConfigurator(Mock.Of<ICommandApp>(), CancellationToken.None);

--- a/tests/Spectre/CommandLine.Spectre.Tests/CommandAppConfiguratorTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/CommandAppConfiguratorTests.cs
@@ -23,7 +23,7 @@ public sealed class CommandAppConfiguratorTests : IDisposable
         var commandApp = new Mock<ICommandApp>();
         Action<IConfigurator> configuration = _ => { };
 
-        new CommandAppConfigurator(commandApp.Object, new CancellationTokenSource()).Configure(configuration);
+        new CommandAppConfigurator(commandApp.Object, CancellationToken.None).Configure(configuration);
 
         commandApp.Verify(app => app.Configure(configuration), Times.Once);
     }
@@ -35,7 +35,7 @@ public sealed class CommandAppConfiguratorTests : IDisposable
         commandApp.Setup(app => app.Run(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>())).Returns(11);
         EnvironmentSettings.Current = new EnvironmentSettings(isDebugging: false, pauseBeforeExit: false, new Dictionary<string, string?>());
 
-        var executor = new CommandAppConfigurator(commandApp.Object, new CancellationTokenSource()).Configure(_ => { });
+        var executor = new CommandAppConfigurator(commandApp.Object, CancellationToken.None).Configure(_ => { });
 
         executor.Run("anything").Should().Be(11, "the executor must run the command app that was configured");
     }
@@ -43,7 +43,7 @@ public sealed class CommandAppConfiguratorTests : IDisposable
     [Fact]
     public void Configure_should_reject_a_null_configuration_action()
     {
-        var configurator = new CommandAppConfigurator(Mock.Of<ICommandApp>(), new CancellationTokenSource());
+        var configurator = new CommandAppConfigurator(Mock.Of<ICommandApp>(), CancellationToken.None);
 
         var act = () => configurator.Configure(null!);
 

--- a/tests/Spectre/CommandLine.Spectre.Tests/CommandAppConfiguratorTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/CommandAppConfiguratorTests.cs
@@ -1,4 +1,4 @@
-using Moq;
+﻿using Moq;
 using Ploch.CommandLine.Spectre.Tests.Testing;
 using Spectre.Console.Cli;
 
@@ -23,7 +23,7 @@ public sealed class CommandAppConfiguratorTests : IDisposable
         var commandApp = new Mock<ICommandApp>();
         Action<IConfigurator> configuration = _ => { };
 
-        new CommandAppConfigurator(commandApp.Object).Configure(configuration);
+        new CommandAppConfigurator(commandApp.Object, new CancellationTokenSource()).Configure(configuration);
 
         commandApp.Verify(app => app.Configure(configuration), Times.Once);
     }
@@ -32,10 +32,10 @@ public sealed class CommandAppConfiguratorTests : IDisposable
     public void Configure_should_return_an_executor_bound_to_the_same_command_app()
     {
         var commandApp = new Mock<ICommandApp>();
-        commandApp.Setup(app => app.Run(It.IsAny<IEnumerable<string>>())).Returns(11);
+        commandApp.Setup(app => app.Run(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>())).Returns(11);
         EnvironmentSettings.Current = new EnvironmentSettings(isDebugging: false, pauseBeforeExit: false, new Dictionary<string, string?>());
 
-        var executor = new CommandAppConfigurator(commandApp.Object).Configure(_ => { });
+        var executor = new CommandAppConfigurator(commandApp.Object, new CancellationTokenSource()).Configure(_ => { });
 
         executor.Run("anything").Should().Be(11, "the executor must run the command app that was configured");
     }
@@ -43,7 +43,7 @@ public sealed class CommandAppConfiguratorTests : IDisposable
     [Fact]
     public void Configure_should_reject_a_null_configuration_action()
     {
-        var configurator = new CommandAppConfigurator(Mock.Of<ICommandApp>());
+        var configurator = new CommandAppConfigurator(Mock.Of<ICommandApp>(), new CancellationTokenSource());
 
         var act = () => configurator.Configure(null!);
 

--- a/tests/Spectre/CommandLine.Spectre.Tests/CommandAppExecutorTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/CommandAppExecutorTests.cs
@@ -1,4 +1,4 @@
-using Moq;
+﻿using Moq;
 using Ploch.CommandLine.Spectre.Tests.Testing;
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -27,23 +27,24 @@ public sealed class CommandAppExecutorTests : IDisposable
     public void Run_should_return_the_exit_code_produced_by_the_command_app()
     {
         var commandApp = new Mock<ICommandApp>();
-        commandApp.Setup(app => app.Run(It.IsAny<IEnumerable<string>>())).Returns(7);
+        commandApp.Setup(app => app.Run(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>())).Returns(7);
         SetPauseBeforeExit(false);
         string[] expectedArguments = ["build", "--verbose"];
 
-        new CommandAppExecutor(commandApp.Object).Run("build", "--verbose").Should().Be(7);
+        new CommandAppExecutor(commandApp.Object, new CancellationTokenSource()).Run("build", "--verbose").Should().Be(7);
 
-        commandApp.Verify(app => app.Run(It.Is<IEnumerable<string>>(args => args.SequenceEqual(expectedArguments))), Times.Once);
+        commandApp.Verify(app => app.Run(It.Is<IEnumerable<string>>(args => args.SequenceEqual(expectedArguments)), It.IsAny<CancellationToken>()),
+                          Times.Once);
     }
 
     [Fact]
     public async Task RunAsync_should_return_the_exit_code_produced_by_the_command_app()
     {
         var commandApp = new Mock<ICommandApp>();
-        commandApp.Setup(app => app.RunAsync(It.IsAny<IEnumerable<string>>())).ReturnsAsync(3);
+        commandApp.Setup(app => app.RunAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(3);
         SetPauseBeforeExit(false);
 
-        var result = await new CommandAppExecutor(commandApp.Object).RunAsync("build");
+        var result = await new CommandAppExecutor(commandApp.Object, new CancellationTokenSource()).RunAsync("build");
 
         result.Should().Be(3);
     }
@@ -54,7 +55,7 @@ public sealed class CommandAppExecutorTests : IDisposable
         using var console = UseRecordingConsole();
         SetPauseBeforeExit(false);
 
-        new CommandAppExecutor(Mock.Of<ICommandApp>()).Run("build");
+        new CommandAppExecutor(Mock.Of<ICommandApp>(), new CancellationTokenSource()).Run("build");
 
         console.Output.Should().BeEmpty("an ordinary invocation must not appear to hang waiting for Enter");
     }
@@ -67,7 +68,7 @@ public sealed class CommandAppExecutorTests : IDisposable
         var input = new TrackingReader();
         Console.SetIn(input);
 
-        new CommandAppExecutor(Mock.Of<ICommandApp>()).Run("build");
+        new CommandAppExecutor(Mock.Of<ICommandApp>(), new CancellationTokenSource()).Run("build");
 
         console.Output.Should().Contain("Press Enter to exit...");
         input.ReadLineCount.Should().Be(1);
@@ -81,10 +82,53 @@ public sealed class CommandAppExecutorTests : IDisposable
         var input = new TrackingReader();
         Console.SetIn(input);
 
-        await new CommandAppExecutor(Mock.Of<ICommandApp>()).RunAsync("build");
+        await new CommandAppExecutor(Mock.Of<ICommandApp>(), new CancellationTokenSource()).RunAsync("build");
 
         console.Output.Should().Contain("Press Enter to exit...");
         input.ReadLineCount.Should().Be(1, "Run and RunAsync must honour the setting identically");
+    }
+
+    [Fact]
+    public void Run_should_hand_Spectre_the_token_of_the_source_it_was_built_with()
+    {
+        var commandApp = new Mock<ICommandApp>();
+        CancellationToken received = default;
+        commandApp.Setup(app => app.Run(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+                  .Callback<IEnumerable<string>, CancellationToken>((_, token) => received = token)
+                  .Returns(0);
+        SetPauseBeforeExit(false);
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        new CommandAppExecutor(commandApp.Object, cancellationTokenSource).Run("build");
+
+        received.CanBeCanceled.Should().BeTrue("a token that can never be cancelled makes the whole feature inert");
+        received.IsCancellationRequested.Should().BeFalse();
+
+        cancellationTokenSource.Cancel();
+
+        received.IsCancellationRequested
+                .Should()
+                .BeTrue("cancelling the source the application was built with must reach the running command");
+    }
+
+    [Fact]
+    public async Task RunAsync_should_hand_Spectre_the_token_of_the_source_it_was_built_with()
+    {
+        var commandApp = new Mock<ICommandApp>();
+        CancellationToken received = default;
+        commandApp.Setup(app => app.RunAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+                  .Callback<IEnumerable<string>, CancellationToken>((_, token) => received = token)
+                  .ReturnsAsync(0);
+        SetPauseBeforeExit(false);
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        await new CommandAppExecutor(commandApp.Object, cancellationTokenSource).RunAsync("build");
+
+        received.CanBeCanceled.Should().BeTrue();
+
+        await cancellationTokenSource.CancelAsync();
+
+        received.IsCancellationRequested.Should().BeTrue();
     }
 
     private static void SetPauseBeforeExit(bool pauseBeforeExit) =>

--- a/tests/Spectre/CommandLine.Spectre.Tests/CommandAppExecutorTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/CommandAppExecutorTests.cs
@@ -31,7 +31,7 @@ public sealed class CommandAppExecutorTests : IDisposable
         SetPauseBeforeExit(false);
         string[] expectedArguments = ["build", "--verbose"];
 
-        new CommandAppExecutor(commandApp.Object, new CancellationTokenSource()).Run("build", "--verbose").Should().Be(7);
+        new CommandAppExecutor(commandApp.Object, CancellationToken.None).Run("build", "--verbose").Should().Be(7);
 
         commandApp.Verify(app => app.Run(It.Is<IEnumerable<string>>(args => args.SequenceEqual(expectedArguments)), It.IsAny<CancellationToken>()),
                           Times.Once);
@@ -44,7 +44,7 @@ public sealed class CommandAppExecutorTests : IDisposable
         commandApp.Setup(app => app.RunAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(3);
         SetPauseBeforeExit(false);
 
-        var result = await new CommandAppExecutor(commandApp.Object, new CancellationTokenSource()).RunAsync("build");
+        var result = await new CommandAppExecutor(commandApp.Object, CancellationToken.None).RunAsync("build");
 
         result.Should().Be(3);
     }
@@ -55,7 +55,7 @@ public sealed class CommandAppExecutorTests : IDisposable
         using var console = UseRecordingConsole();
         SetPauseBeforeExit(false);
 
-        new CommandAppExecutor(Mock.Of<ICommandApp>(), new CancellationTokenSource()).Run("build");
+        new CommandAppExecutor(Mock.Of<ICommandApp>(), CancellationToken.None).Run("build");
 
         console.Output.Should().BeEmpty("an ordinary invocation must not appear to hang waiting for Enter");
     }
@@ -68,7 +68,7 @@ public sealed class CommandAppExecutorTests : IDisposable
         var input = new TrackingReader();
         Console.SetIn(input);
 
-        new CommandAppExecutor(Mock.Of<ICommandApp>(), new CancellationTokenSource()).Run("build");
+        new CommandAppExecutor(Mock.Of<ICommandApp>(), CancellationToken.None).Run("build");
 
         console.Output.Should().Contain("Press Enter to exit...");
         input.ReadLineCount.Should().Be(1);
@@ -82,14 +82,14 @@ public sealed class CommandAppExecutorTests : IDisposable
         var input = new TrackingReader();
         Console.SetIn(input);
 
-        await new CommandAppExecutor(Mock.Of<ICommandApp>(), new CancellationTokenSource()).RunAsync("build");
+        await new CommandAppExecutor(Mock.Of<ICommandApp>(), CancellationToken.None).RunAsync("build");
 
         console.Output.Should().Contain("Press Enter to exit...");
         input.ReadLineCount.Should().Be(1, "Run and RunAsync must honour the setting identically");
     }
 
     [Fact]
-    public void Run_should_hand_Spectre_the_token_of_the_source_it_was_built_with()
+    public void Run_should_hand_Spectre_the_token_it_was_built_with()
     {
         var commandApp = new Mock<ICommandApp>();
         CancellationToken received = default;
@@ -99,7 +99,7 @@ public sealed class CommandAppExecutorTests : IDisposable
         SetPauseBeforeExit(false);
         using var cancellationTokenSource = new CancellationTokenSource();
 
-        new CommandAppExecutor(commandApp.Object, cancellationTokenSource).Run("build");
+        new CommandAppExecutor(commandApp.Object, cancellationTokenSource.Token).Run("build");
 
         received.CanBeCanceled.Should().BeTrue("a token that can never be cancelled makes the whole feature inert");
         received.IsCancellationRequested.Should().BeFalse();
@@ -112,7 +112,7 @@ public sealed class CommandAppExecutorTests : IDisposable
     }
 
     [Fact]
-    public async Task RunAsync_should_hand_Spectre_the_token_of_the_source_it_was_built_with()
+    public async Task RunAsync_should_hand_Spectre_the_token_it_was_built_with()
     {
         var commandApp = new Mock<ICommandApp>();
         CancellationToken received = default;
@@ -122,7 +122,7 @@ public sealed class CommandAppExecutorTests : IDisposable
         SetPauseBeforeExit(false);
         using var cancellationTokenSource = new CancellationTokenSource();
 
-        await new CommandAppExecutor(commandApp.Object, cancellationTokenSource).RunAsync("build");
+        await new CommandAppExecutor(commandApp.Object, cancellationTokenSource.Token).RunAsync("build");
 
         received.CanBeCanceled.Should().BeTrue();
 

--- a/tests/Spectre/CommandLine.Spectre.Tests/CommandAppExecutorTests.cs
+++ b/tests/Spectre/CommandLine.Spectre.Tests/CommandAppExecutorTests.cs
@@ -131,6 +131,42 @@ public sealed class CommandAppExecutorTests : IDisposable
         received.IsCancellationRequested.Should().BeTrue();
     }
 
+    /// <summary>
+    ///     Wiring the token up made this reachable: a cancelled run that also had PauseBeforeExit set would print
+    ///     "Press Enter to exit..." and block on stdin, turning the shutdown the user just asked for into a hang.
+    /// </summary>
+    [Fact]
+    public void Run_should_not_pause_for_input_when_the_run_was_cancelled()
+    {
+        using var console = UseRecordingConsole();
+        SetPauseBeforeExit(true);
+        var input = new TrackingReader();
+        Console.SetIn(input);
+        using var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.Cancel();
+
+        new CommandAppExecutor(Mock.Of<ICommandApp>(), cancellationTokenSource.Token).Run("build");
+
+        input.ReadLineCount.Should().Be(0, "the user has already asked the application to stop");
+        console.Output.Should().NotContain("Press Enter to exit...");
+    }
+
+    [Fact]
+    public async Task RunAsync_should_not_pause_for_input_when_the_run_was_cancelled()
+    {
+        using var console = UseRecordingConsole();
+        SetPauseBeforeExit(true);
+        var input = new TrackingReader();
+        Console.SetIn(input);
+        using var cancellationTokenSource = new CancellationTokenSource();
+        await cancellationTokenSource.CancelAsync();
+
+        await new CommandAppExecutor(Mock.Of<ICommandApp>(), cancellationTokenSource.Token).RunAsync("build");
+
+        input.ReadLineCount.Should().Be(0, "Run and RunAsync must honour cancellation identically");
+        console.Output.Should().NotContain("Press Enter to exit...");
+    }
+
     private static void SetPauseBeforeExit(bool pauseBeforeExit) =>
         EnvironmentSettings.Current = new EnvironmentSettings(isDebugging: false, pauseBeforeExit, new Dictionary<string, string?>());
 


### PR DESCRIPTION
## **User description**
## Summary

The cancellation feature did not work. `AppBuilder.Create` built a `CancellationTokenSource` and cancelled it on Ctrl+C, but nothing consumed it — so every command received a token that could never fire.

Found by GitHub Copilot's PR reviewer on #11.

Refs #14, refs #32.

## The defect

`CommandAppExecutor` called the token-less Spectre overloads:

```csharp
var result = commandApp.Run(args);
var result = await commandApp.RunAsync(args).ConfigureAwait(false);
```

Spectre.Console.Cli **0.53.1** — the version in use — provides both:

```
ICommandApp.Run(IEnumerable<string>, CancellationToken)
ICommandApp.RunAsync(IEnumerable<string>, CancellationToken)
```

That token parameter is the **only** channel from the builder's source to a command. `AppBuilder` registered the `CancellationTokenSource` in the container (`services.AddSingleton(cancellationTokenSource)`) and `grep` across `src/` finds nothing resolving it. So Ctrl+C cancelled a source nobody read, and `DoExecute`/`DoExecuteAsync` were handed a default token.

**Combined with the unconditional `e.Cancel = true`, Ctrl+C did nothing at all** — it neither cancelled the command nor terminated the process.

## Changes

**`CommandAppExecutor`** takes a `CancellationToken` and passes it to
`ICommandApp.Run(args, token)` and `ICommandApp.RunAsync(args, token)`. It also skips the
"Press Enter to exit..." pause when the token is already cancelled, so a shutdown the user
just asked for does not turn into a wait on stdin.

**`AppBuilder.ConfigureCommandApp`** passes the token of the source it already owns — the value
was in scope and unused.

**`AppBuilder.Create`** gives Ctrl+C an escape hatch. The handler is one-shot and detaches itself,
so the first interrupt cancels cooperatively and a second takes the default path and terminates:

```csharp
void OnCancelKeyPress(object? sender, ConsoleCancelEventArgs e)
{
    if (Interlocked.Exchange(ref interruptHandled, 1) != 0)
    {
        e.Cancel = false;

        return;
    }

    Console.CancelKeyPress -= OnCancelKeyPress;
    e.Cancel = true;

    try
    {
        cancellationTokenSource.Cancel();
    }
    catch (ObjectDisposedException)
    {
        e.Cancel = false;

        return;
    }
    catch (AggregateException exception)
    {
        AnsiConsole.WriteLine($"A cancellation callback failed during shutdown: {exception.Message}");
    }

    AnsiConsole.WriteLine("Shutting down... press Ctrl+C again to force an exit.");
}
```

Cancelling before writing is deliberate: this runs on the `CancelKeyPress` thread, where console
I/O can block or throw, so writing first risks suppressing termination without ever cancelling.

**`CommandAppConfigurator`** builds an executor too and had no token to give it. It now takes one —
required rather than optional, so an application configured through that entry point cannot
silently lose cancellation.

## Rebased onto the merged `main`

This branch was cut from the #11 branch, which was **squash-merged**, so its commits are not
ancestors of `main` and the PR showed a spurious 428-file diff. It has been rebased with
`git rebase --onto origin/main f23b852`; every commit builds individually.

The conflict was real rather than textual. `main` now has `AppBuilder` implementing `IDisposable`
and owning both the cancellation source and the handler subscription. The two changes **compose**:
the builder releases both on `Dispose`, and the handler additionally detaches itself once an
interrupt has been handled, so whichever happens first wins and removing an already-removed handler
is a no-op.

One behaviour is new to the merge and belongs to neither change alone: an interrupt arriving **after
the builder has been disposed** is handed back to the default path (`e.Cancel = false`) rather than
suppressed. The run it exists to interrupt is already over, and a press that neither cancels nor
terminates is precisely the unkillable behaviour this change set removes.

## What this does not close

#32 asked for two things, and both are now addressed — but by two different changes. The ownership
and disposal model (handler accumulation across repeated `AppBuilder.Create` calls, and disposing the
source) landed on `main` with #11; this PR fixes the escape hatch. One residual case is inherent
rather than outstanding: a caller that never disposes its builder and is never interrupted still
leaves the subscription installed for the lifetime of the process, which is what not disposing an
`IDisposable` means.

Whether #32 closes on merge is the maintainer's call; this PR does not close it automatically.

## Testing

Regression tests assert exactly what was absent — that the token Spectre receives is live, and that
cancelling the builder's source is observed through it:

```csharp
received.CanBeCanceled.Should().BeTrue("a token that can never be cancelled makes the whole feature inert");
cancellationTokenSource.Cancel();
received.IsCancellationRequested.Should().BeTrue("cancelling the source the application was built with must reach the running command");
```

Both `Run` and `RunAsync` are covered, on the executor and now on the configurator too. Added after
review:

- **The Ctrl+C contract.** Four tests drive the real handler, one per branch: the first interrupt
  cancels the token and suppresses termination, a second is not suppressed, one arriving after
  disposal is handed back to the default path, and a consumer callback that throws is reported
  rather than allowed to escape and kill the process. The handler is reached through the field the builder keeps it in, because
  `Console.CancelKeyPress` cannot be raised from a test and `ConsoleCancelEventArgs` has no public
  constructor — verified by reflection: zero public constructors, one non-public taking a
  `ConsoleSpecialKey`. Confirmed by mutation: disabling the one-shot guard fails the second-interrupt
  test, and making the disposed path suppress the interrupt fails two of the three.
- **The configurator's token.** Every previous test passed `CancellationToken.None` and matched
  `It.IsAny<CancellationToken>()`, so a configurator that discarded its token would have passed all of
  them. Confirmed by mutation: degrading the token to `None` fails the new test alone.

```
dotnet build -c Debug   ->  0 Warning(s), 0 Error(s)   (every commit on the branch)
dotnet test  -c Debug   ->  232 passed, 0 failed  (Ploch.CommandLine.Spectre.Tests)
                            all 8 assemblies pass
```

## Breaking changes

`CommandAppExecutor` and `CommandAppConfigurator` take a **`CancellationToken`** as a required second
constructor argument — not a `CancellationTokenSource`. Code constructing either directly passes
`cancellationTokenSource.Token`, or `CancellationToken.None` where cancellation is not required.
A token is taken rather than the source because neither type ever calls `Cancel`, and because a token
captured up front stays usable after its source is disposed. Recorded in
`change-log/14-wire-cancellation-token.md`.

## Related

- Refs #14 — makes the cancellation plumbing real rather than nominal
- Refs #32 — fixes the escape hatch half only

## Summary by Sourcery

Wire Ctrl+C cancellation through to running commands and preserve a force-exit path when graceful shutdown is not honored.

New Features:
- Connect application cancellation tokens to synchronous and asynchronous Spectre command execution.
- Allow a first Ctrl+C to request graceful shutdown and a subsequent Ctrl+C to force termination.

Bug Fixes:
- Prevent cancelled runs from blocking on the exit prompt.
- Handle cancellation races and callback failures without leaving the process unresponsive or crashing the cancellation thread.

Enhancements:
- Require cancellation tokens when constructing command executors and configurators so cancellation cannot be silently dropped.

Documentation:
- Document the cancellation-token wiring and behavior in the change log.

Tests:
- Add regression coverage for token propagation, cancellation behavior, Ctrl+C handling, disposal races, callback failures, and cancelled-run shutdown behavior.


___

## **CodeAnt-AI Description**
Connect Ctrl+C cancellation to running commands and prevent shutdown hangs

### What Changed
- Commands now receive the application's cancellable token for both synchronous and asynchronous runs, so Ctrl+C can stop commands that honor cancellation.
- The first Ctrl+C requests a graceful shutdown; a second Ctrl+C can force the process to exit if the command does not stop.
- Cancelled runs no longer wait for the “Press Enter to exit...” prompt.
- Cancellation callback failures are reported without crashing the shutdown thread.
- Direct users of the executor and configurator must now provide a cancellation token.

### Impact
`✅ Ctrl+C stops cancellation-aware commands`
`✅ Fewer shutdown hangs`
`✅ Force exit available when commands ignore cancellation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


 
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ctrl+C now supports cooperative cancellation: the first press cancels the running command, while a second press forcefully terminates the process.
  * Cancellation is consistently propagated to commands, enabling responsive shutdown.
* **Bug Fixes**
  * Cancellation handlers now clean up safely and report callback errors without disrupting the application.
  * Cancelled runs no longer display or wait for the “Press Enter to exit…” prompt.
* **Documentation**
  * Updated getting-started, builder, and changelog documentation with the new cancellation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai --> 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This change hardens AppBuilder's Ctrl+C cancellation lifecycle by preventing disposal from overlapping an active CancellationTokenSource.Cancel() call. It defers source release when disposal occurs inside a synchronous cancellation callback, preserves cooperative interrupt handling, and adds regression coverage and documentation for the race.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>AppBuilder introduces CancelInProgress and DisposeDeferred state in InterruptGate so cancellation callbacks can safely dispose the builder without releasing the CancellationTokenSource while Cancel() is still unwinding, in AppBuilder.cs.</li>

<li>Cancellation now executes outside the lifetime lock, while deferred release is completed in the cancellation handler's finally block; callback failures are still reported after the interrupt is marked handled, in AppBuilder.cs.</li>

<li>Adds a regression test that disposes AppBuilder from a cancellation callback and verifies that cancellation completes without throwing and that the source is disposed afterward, in AppBuilderTests.cs.</li>

<li>Updates the documented post-disposal interrupt behavior to explain why the handler leaves shared event arguments unchanged rather than explicitly assigning e.Cancel = false, in 14-wire-cancellation-token.md.</li>

</ul>
</details>

</div>