### PR TITLE
fix(github-actions): Publish the packages the build actually produces

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,11 @@
 ###############################################################################
 * text=auto
 
+# Shell scripts must keep LF in the working tree on every platform: bash does not
+# tolerate CRLF, and a script checked out with CRLF fails on the Linux CI runner with
+# `bad interpreter: /usr/bin/env bash^M`.
+*.sh    text eol=lf
+
 ###############################################################################
 # Set default behavior for command prompt diff.
 #

--- a/.github/scripts/publish-nuget-packages.sh
+++ b/.github/scripts/publish-nuget-packages.sh
@@ -28,12 +28,26 @@ FEED_URL="${1:?Usage: publish-nuget-packages.sh <feed-url>}"
 # produced four levels down. An unmatched glob is then passed through literally and
 # `dotnet nuget push` exits 0 on it - the step reports success having published nothing.
 #
-# tests/ and samples/ are excluded defensively rather than because they would otherwise
-# pack: test projects set IsPackable=false, and samples/SampleApp/Directory.Build.props
-# sets GeneratePackageOnBuild=false and IsPackable=false. `-ipath` keeps the exclusion
-# honest if either directory is ever renamed with different casing.
+# Restricted to bin/Release: Directory.Build.props sets GeneratePackageOnBuild=true for every
+# non-test project, so a library packs on EVERY build, not only the Release one. The workflow
+# builds these projects more than once, and a Debug pack therefore sits beside the Release pack
+# carrying the identical version. Unfiltered, `sort` orders 'bin/Debug' before 'bin/Release', so
+# the Debug artefact claims the version on the feed and --skip-duplicate silently swallows the
+# Release one that follows. That is not hypothetical: run 33169218883 on this very branch pushed
+# the Debug build of all four packages and reported success --
+#
+#   Publishing ./src/Spectre/CommandLine.Spectre/bin/Debug/...nupkg   -> Your package was pushed.
+#   Publishing ./src/Spectre/CommandLine.Spectre/bin/Release/...nupkg -> already exists at feed
+#
+# which is the same shape of failure this script exists to remove: a green step shipping the
+# wrong thing.
+#
+# tests/ and samples/ are excluded defensively rather than because they would otherwise pack:
+# test projects set IsPackable=false, and samples/SampleApp/Directory.Build.props sets
+# GeneratePackageOnBuild=false and IsPackable=false. `-ipath` keeps every path predicate honest
+# if a directory is ever renamed with different casing.
 find_packages() {
-  find . -type f -name "$1" -not -ipath './tests/*' -not -ipath './samples/*' | sort
+  find . -type f -name "$1" -ipath '*/bin/Release/*' -not -ipath './tests/*' -not -ipath './samples/*' | sort
 }
 
 # Captured into a variable rather than piped into `mapfile` through a process substitution:
@@ -46,7 +60,7 @@ if ! packages_found=$(find_packages '*.nupkg'); then
 fi
 
 if [ -z "$packages_found" ]; then
-  echo "::error::No .nupkg files were found. Refusing to report a successful publish."
+  echo "::error::No Release .nupkg files were found. Refusing to report a successful publish."
   exit 1
 fi
 

--- a/.github/scripts/publish-nuget-packages.sh
+++ b/.github/scripts/publish-nuget-packages.sh
@@ -47,7 +47,9 @@ FEED_URL="${1:?Usage: publish-nuget-packages.sh <feed-url>}"
 # GeneratePackageOnBuild=false and IsPackable=false. `-ipath` keeps every path predicate honest
 # if a directory is ever renamed with different casing.
 find_packages() {
-  find . -type f -name "$1" -ipath '*/bin/Release/*' -not -ipath './tests/*' -not -ipath './samples/*' | sort
+  local pattern="$1"
+
+  find . -type f -name "$pattern" -ipath '*/bin/Release/*' -not -ipath './tests/*' -not -ipath './samples/*' | sort
 }
 
 # Captured into a variable rather than piped into `mapfile` through a process substitution:
@@ -55,12 +57,12 @@ find_packages() {
 # after a partial result would publish a subset of the packages and report success.
 # `set -o pipefail` makes the failing `find` fail the whole `find | sort` pipeline.
 if ! packages_found=$(find_packages '*.nupkg'); then
-  echo "::error::Package discovery failed while enumerating .nupkg files."
+  echo "::error::Package discovery failed while enumerating .nupkg files." >&2
   exit 1
 fi
 
-if [ -z "$packages_found" ]; then
-  echo "::error::No Release .nupkg files were found. Refusing to report a successful publish."
+if [[ -z "$packages_found" ]]; then
+  echo "::error::No Release .nupkg files were found. Refusing to report a successful publish." >&2
   exit 1
 fi
 
@@ -78,7 +80,7 @@ if ! symbols_found=$(find_packages '*.snupkg'); then
   symbols_found=''
 fi
 
-if [ -n "$symbols_found" ]; then
+if [[ -n "$symbols_found" ]]; then
   mapfile -t symbols <<< "$symbols_found"
   for sym in "${symbols[@]}"; do
     echo "Publishing $sym"

--- a/.github/scripts/publish-nuget-packages.sh
+++ b/.github/scripts/publish-nuget-packages.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# Publishes every NuGet package the build produced to the given feed.
+#
+# Usage:  publish-nuget-packages.sh <feed-url>
+# Reads:  GH_PACKAGES_TOKEN - the feed API key. Taken from the environment so that this
+#         script's own arguments carry nothing secret. That narrows the exposure, it does
+#         not remove it: `dotnet nuget push -k` still places the key in the dotnet
+#         process's command line, where it is readable from /proc for the life of that
+#         process. Eliminating it entirely would need an auth mechanism `nuget push`
+#         does not currently offer.
+#
+# Why a script and not two inline `run:` blocks: the main-branch and pull-request publish
+# steps previously carried a copy each of this logic, and the `./**/*.nupkg` glob bug that
+# published nothing was therefore present twice. One implementation cannot drift from itself.
+set -euo pipefail
+
+FEED_URL="${1:?Usage: publish-nuget-packages.sh <feed-url>}"
+: "${GH_PACKAGES_TOKEN:?GH_PACKAGES_TOKEN must be set}"
+
+# Enumerated with `find`, never a glob: globstar is off by default and GitHub runs steps
+# with `bash -e`, so `./**/*.nupkg` matches a single directory level while packages are
+# produced four levels down. An unmatched glob is then passed through literally and
+# `dotnet nuget push` exits 0 on it - the step reports success having published nothing.
+#
+# tests/ and samples/ are excluded defensively rather than because they would otherwise
+# pack: test projects set IsPackable=false, and samples/SampleApp/Directory.Build.props
+# sets GeneratePackageOnBuild=false and IsPackable=false. `-ipath` keeps the exclusion
+# honest if either directory is ever renamed with different casing.
+find_packages() {
+  find . -type f -name "$1" -not -ipath './tests/*' -not -ipath './samples/*' | sort
+}
+
+# Captured into a variable rather than piped into `mapfile` through a process substitution:
+# `mapfile < <(find ...)` discards find's exit status, so a traversal error that occurred
+# after a partial result would publish a subset of the packages and report success.
+# `set -o pipefail` makes the failing `find` fail the whole `find | sort` pipeline.
+if ! packages_found=$(find_packages '*.nupkg'); then
+  echo "::error::Package discovery failed while enumerating .nupkg files."
+  exit 1
+fi
+
+if [ -z "$packages_found" ]; then
+  echo "::error::No .nupkg files were found. Refusing to report a successful publish."
+  exit 1
+fi
+
+mapfile -t packages <<< "$packages_found"
+
+for pkg in "${packages[@]}"; do
+  echo "Publishing $pkg"
+  dotnet nuget push "$pkg" --source "$FEED_URL" --skip-duplicate -k "$GH_PACKAGES_TOKEN"
+done
+
+# Symbol packages are best-effort: a missing or unpushable .snupkg is not a failed release,
+# so a discovery failure here warns instead of exiting.
+if ! symbols_found=$(find_packages '*.snupkg'); then
+  echo "::warning::Symbol package discovery failed; publishing without symbol packages."
+  symbols_found=''
+fi
+
+if [ -n "$symbols_found" ]; then
+  mapfile -t symbols <<< "$symbols_found"
+  for sym in "${symbols[@]}"; do
+    echo "Publishing $sym"
+    dotnet nuget push "$sym" --source "$FEED_URL" --skip-duplicate -k "$GH_PACKAGES_TOKEN" || true
+  done
+fi

--- a/.github/scripts/publish-nuget-packages.sh
+++ b/.github/scripts/publish-nuget-packages.sh
@@ -7,8 +7,13 @@
 #         script's own arguments carry nothing secret. That narrows the exposure, it does
 #         not remove it: `dotnet nuget push -k` still places the key in the dotnet
 #         process's command line, where it is readable from /proc for the life of that
-#         process. Eliminating it entirely would need an auth mechanism `nuget push`
-#         does not currently offer.
+#         process. NuGet.Config already carries packageSourceCredentials for the "github"
+#         source using %GH_PACKAGES_TOKEN%, so pushing to the source name instead of the
+#         URL would drop `-k` and keep the key off every command line. That is deferred to
+#         #45 rather than changed here: this publish path is not exercised by CI on a PR
+#         targeting a feature branch, so a credential-resolution failure would first show
+#         up on a push to main - a bad place to discover it, in the very step this branch
+#         exists to make reliable.
 #
 # Why a script and not two inline `run:` blocks: the main-branch and pull-request publish
 # steps previously carried a copy each of this logic, and the `./**/*.nupkg` glob bug that

--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -259,8 +259,29 @@ jobs:
       - name: Publish NuGet packages to GitHub Packages
         if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
-          dotnet nuget push ./**/*.nupkg --source https://nuget.pkg.github.com/mrploch/index.json --skip-duplicate -k "$GH_PACKAGES_TOKEN"
-          dotnet nuget push ./**/*.snupkg --source https://nuget.pkg.github.com/mrploch/index.json --skip-duplicate -k "$GH_PACKAGES_TOKEN" || true
+          # `**` does not recurse here: globstar is off by default and GitHub runs steps with
+          # `bash -e`, so `./**/*.nupkg` matches a single directory level while packages are
+          # produced four levels down. Worse, an unmatched glob is passed through literally and
+          # `dotnet nuget push` exits 0 on it, so this step would report success having published
+          # nothing. tests/ and samples/ are excluded because Directory.Build.props packs every
+          # non-test project and the sample solution is built in Release above.
+          mapfile -t PACKAGES < <(find . -type f -name '*.nupkg' -not -path './tests/*' -not -path './samples/*' | sort)
+
+          if [ ${#PACKAGES[@]} -eq 0 ]; then
+            echo "::error::No .nupkg files were found. Refusing to report a successful publish."
+            exit 1
+          fi
+
+          for pkg in "${PACKAGES[@]}"; do
+            echo "Publishing $pkg"
+            dotnet nuget push "$pkg" --source https://nuget.pkg.github.com/mrploch/index.json --skip-duplicate -k "$GH_PACKAGES_TOKEN"
+          done
+
+          # Symbol packages are best-effort: a missing .snupkg is not a failed release.
+          find . -type f -name '*.snupkg' -not -path './tests/*' -not -path './samples/*' | sort | while IFS= read -r sym; do
+            echo "Publishing $sym"
+            dotnet nuget push "$sym" --source https://nuget.pkg.github.com/mrploch/index.json --skip-duplicate -k "$GH_PACKAGES_TOKEN" || true
+          done
 
       # Publish PR packages to GitHub Packages for testing/validation.
       # PR packages include the PR number and branch name in the prerelease tag
@@ -277,5 +298,21 @@ jobs:
             echo "::warning::GH_PACKAGES_TOKEN not available, skipping PR package publish"
             exit 0
           fi
-          dotnet nuget push ./**/*.nupkg --source https://nuget.pkg.github.com/mrploch/index.json --skip-duplicate -k "$GH_PACKAGES_TOKEN"
-          dotnet nuget push ./**/*.snupkg --source https://nuget.pkg.github.com/mrploch/index.json --skip-duplicate -k "$GH_PACKAGES_TOKEN" || true
+          # Same enumeration as the main-branch publish above; see the comment there for why a
+          # `./**/*.nupkg` glob silently publishes nothing.
+          mapfile -t PACKAGES < <(find . -type f -name '*.nupkg' -not -path './tests/*' -not -path './samples/*' | sort)
+
+          if [ ${#PACKAGES[@]} -eq 0 ]; then
+            echo "::error::No .nupkg files were found. Refusing to report a successful publish."
+            exit 1
+          fi
+
+          for pkg in "${PACKAGES[@]}"; do
+            echo "Publishing $pkg"
+            dotnet nuget push "$pkg" --source https://nuget.pkg.github.com/mrploch/index.json --skip-duplicate -k "$GH_PACKAGES_TOKEN"
+          done
+
+          find . -type f -name '*.snupkg' -not -path './tests/*' -not -path './samples/*' | sort | while IFS= read -r sym; do
+            echo "Publishing $sym"
+            dotnet nuget push "$sym" --source https://nuget.pkg.github.com/mrploch/index.json --skip-duplicate -k "$GH_PACKAGES_TOKEN" || true
+          done

--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -258,30 +258,7 @@ jobs:
       # available package sources". `nuget push` accepts a URL, so no source is needed.
       - name: Publish NuGet packages to GitHub Packages
         if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: |
-          # `**` does not recurse here: globstar is off by default and GitHub runs steps with
-          # `bash -e`, so `./**/*.nupkg` matches a single directory level while packages are
-          # produced four levels down. Worse, an unmatched glob is passed through literally and
-          # `dotnet nuget push` exits 0 on it, so this step would report success having published
-          # nothing. tests/ and samples/ are excluded because Directory.Build.props packs every
-          # non-test project and the sample solution is built in Release above.
-          mapfile -t PACKAGES < <(find . -type f -name '*.nupkg' -not -path './tests/*' -not -path './samples/*' | sort)
-
-          if [ ${#PACKAGES[@]} -eq 0 ]; then
-            echo "::error::No .nupkg files were found. Refusing to report a successful publish."
-            exit 1
-          fi
-
-          for pkg in "${PACKAGES[@]}"; do
-            echo "Publishing $pkg"
-            dotnet nuget push "$pkg" --source https://nuget.pkg.github.com/mrploch/index.json --skip-duplicate -k "$GH_PACKAGES_TOKEN"
-          done
-
-          # Symbol packages are best-effort: a missing .snupkg is not a failed release.
-          find . -type f -name '*.snupkg' -not -path './tests/*' -not -path './samples/*' | sort | while IFS= read -r sym; do
-            echo "Publishing $sym"
-            dotnet nuget push "$sym" --source https://nuget.pkg.github.com/mrploch/index.json --skip-duplicate -k "$GH_PACKAGES_TOKEN" || true
-          done
+        run: bash .github/scripts/publish-nuget-packages.sh https://nuget.pkg.github.com/mrploch/index.json
 
       # Publish PR packages to GitHub Packages for testing/validation.
       # PR packages include the PR number and branch name in the prerelease tag
@@ -298,21 +275,4 @@ jobs:
             echo "::warning::GH_PACKAGES_TOKEN not available, skipping PR package publish"
             exit 0
           fi
-          # Same enumeration as the main-branch publish above; see the comment there for why a
-          # `./**/*.nupkg` glob silently publishes nothing.
-          mapfile -t PACKAGES < <(find . -type f -name '*.nupkg' -not -path './tests/*' -not -path './samples/*' | sort)
-
-          if [ ${#PACKAGES[@]} -eq 0 ]; then
-            echo "::error::No .nupkg files were found. Refusing to report a successful publish."
-            exit 1
-          fi
-
-          for pkg in "${PACKAGES[@]}"; do
-            echo "Publishing $pkg"
-            dotnet nuget push "$pkg" --source https://nuget.pkg.github.com/mrploch/index.json --skip-duplicate -k "$GH_PACKAGES_TOKEN"
-          done
-
-          find . -type f -name '*.snupkg' -not -path './tests/*' -not -path './samples/*' | sort | while IFS= read -r sym; do
-            echo "Publishing $sym"
-            dotnet nuget push "$sym" --source https://nuget.pkg.github.com/mrploch/index.json --skip-duplicate -k "$GH_PACKAGES_TOKEN" || true
-          done
+          bash .github/scripts/publish-nuget-packages.sh https://nuget.pkg.github.com/mrploch/index.json


### PR DESCRIPTION
## **User description**
## Summary

Both GitHub Packages publish steps would have **reported success while publishing nothing**. This has never been seen because the step is gated on `refs/heads/main` and nothing has been pushed there — the first push, which is what merging #11 does, would have been the first occurrence.

Found by GitHub Copilot's PR reviewer on #11. Closes #43.

## The defect

```bash
dotnet nuget push ./**/*.nupkg --source https://nuget.pkg.github.com/mrploch/index.json --skip-duplicate -k "$GH_PACKAGES_TOKEN"
```

`**` does not recurse. `globstar` is off by default and GitHub runs steps with `bash -e` without enabling it, so the pattern is equivalent to `./*/*.nupkg` — one directory level. Packages are produced at `src/Spectre/<Project>/bin/Release/`, four levels down.

Verified against a fixture mirroring the real layout:

```
globstar OFF  ->  argc=1   [./one/Shallow.nupkg]
globstar ON   ->  argc=3   [./one/Shallow.nupkg]
                           [./src/Spectre/CommandLine.Spectre/bin/Release/A.nupkg]
                           [./src/Spectre/CommandLine.Spectre.Serilog/bin/Release/B.nupkg]
```

**And the failure is silent.** An unmatched glob is passed through literally, and `dotnet nuget push` given a non-matching literal exits `0` without publishing:

```
$ bash -c "shopt -u globstar; dotnet nuget push './**/*.snupkg' --source <local feed> --skip-duplicate"
exit=0
```

No error, no warning, green step, zero packages — and #7 would have looked satisfied.

## Why not just enable globstar

That swaps one defect for another. `Directory.Build.props` sets `GeneratePackageOnBuild=true` for every non-test project, and the workflow builds the sample solution in Release at line 175, so `samples/SampleApp/src/SampleApp/bin/Release/*.nupkg` exists on the runner. A recursive glob would publish the demo application to the feed.

## The fix

Both steps enumerate with `find`, excluding `tests/` and `samples/` — the same shape `release.yml` already uses — and **fail when nothing is found**:

```bash
mapfile -t PACKAGES < <(find . -type f -name '*.nupkg' -not -path './tests/*' -not -path './samples/*' | sort)

if [ ${#PACKAGES[@]} -eq 0 ]; then
  echo "::error::No .nupkg files were found. Refusing to report a successful publish."
  exit 1
fi

for pkg in "${PACKAGES[@]}"; do
  dotnet nuget push "$pkg" --source ... --skip-duplicate -k "$GH_PACKAGES_TOKEN"
done
```

Symbol packages stay best-effort — a missing `.snupkg` is not a failed release — but are enumerated the same way rather than globbed.

## Testing

Workflow YAML parses, and no `dotnet nuget push` command containing `**` remains in either step. Behaviour verified against a fixture with two library packages, one sample package and one test package:

```
CASE 1: normal build
  would publish: ./src/Spectre/CommandLine.Spectre.Serilog/bin/Release/...nupkg
  would publish: ./src/Spectre/CommandLine.Spectre/bin/Release/...nupkg
  count=2                                  # sample and test correctly excluded
  exit=0

CASE 2: nothing produced
  ::error::No .nupkg files were found.
  exit=1                                   # fails loudly instead of passing silently
```

No source code is touched, so build and tests are unaffected.

## Related

- Closes #43
- Unblocks #7 in substance — the packages will now actually reach the feed on the first push to `main`

## Summary by Sourcery

Make GitHub Actions publish the packages actually produced by the build and fail clearly when package discovery yields no publishable artifacts.

Bug Fixes:
- Fix GitHub Actions NuGet publishing so all intended Release packages are discovered and published instead of silently publishing nothing.
- Fail package publishing when regular packages cannot be discovered or none are produced.

Enhancements:
- Exclude test and sample artifacts from package publishing while keeping symbol packages best-effort.
- Consolidate main-branch and pull-request publishing into a shared script to keep their behavior consistent.

CI:
- Enforce Linux-compatible line endings for shell scripts used by CI.


___

## **CodeAnt-AI Description**
Publish the packages produced by the build reliably

### What Changed
- NuGet publishing now discovers packages in all build directories instead of relying on a non-recursive pattern that could publish nothing while reporting success
- Test and sample packages are excluded from publishing
- Publishing fails clearly when no regular packages are found or package discovery fails
- Main-branch and eligible pull-request builds use the same publishing behavior
- Symbol packages remain optional, with discovery or upload problems reported as warnings
- Shell scripts retain Linux-compatible line endings across platforms

### Impact
`✅ Fewer empty successful publishes`
`✅ Only intended library packages reach GitHub Packages`
`✅ Clearer package publishing failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details> 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR makes GitHub Actions publish the intended NuGet artifacts by centralizing package discovery and restricting regular packages to Release outputs. It also preserves optional symbol publishing behavior and enforces Linux-compatible shell-script line endings for CI.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>The publishing script continues to pass the feed credential through the dotnet process command line, leaving the documented process-list exposure unresolved in publish-nuget-packages.sh; migration to source-based credential resolution is deferred.</li>

<li>Package discovery in publish-nuget-packages.sh now filters for bin/Release artifacts, preventing earlier Debug packages with the same version from being published first and causing the intended Release packages to be skipped by --skip-duplicate.</li>

<li>Regular package discovery failures and empty Release results now emit GitHub Actions errors to stderr and exit nonzero, while symbol-package discovery and upload remain best-effort.</li>

<li>The .gitattributes rule forces LF endings for all .sh files, preventing CRLF-related Bash interpreter failures on Linux CI runners.</li>

</ul>
</details>

</div>